### PR TITLE
Fixed a bug in add operation function

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/ConfigOperation.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/ConfigOperation.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.device.mgt.core.operation.mgt;
 
 import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class ConfigOperation extends Operation {
         properties.add(new Property(name, value, type));
     }
 
-    public class Property {
+    public class Property implements Serializable{
         private String name;
         private Object value;
         private Class<?> type;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/ConfigOperation.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/ConfigOperation.java
@@ -40,7 +40,7 @@ public class ConfigOperation extends Operation {
         properties.add(new Property(name, value, type));
     }
 
-    public class Property implements Serializable{
+    public class Property implements Serializable {
         private String name;
         private Object value;
         private Class<?> type;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -76,6 +76,8 @@ public class OperationManagerImpl implements OperationManager {
             OperationManagementDAOFactory.beginTransaction();
             org.wso2.carbon.device.mgt.core.dto.operation.mgt.Operation operationDto =
                     OperationDAOUtil.convertOperation(operation);
+            operationDto.setStatus(org.wso2.carbon.device.mgt.core.dto.operation.mgt.Operation.Status.PENDING);
+
             int operationId = this.lookupOperationDAO(operation).addOperation(operationDto);
             org.wso2.carbon.device.mgt.common.Device device;
 


### PR DESCRIPTION
When it comes to storing profile operation in the table, it stores status of the operation as 'null', thus it results a NullPointerException when it comes to retrieving this object back.
