### PR TITLE
Revert "Fix for JIRA IOTS-65"

### DIFF
--- a/components/common-api/org.wso2.carbon.device.mgt.common.impl/src/main/java/org/wso2/carbon/device/mgt/common/impl/config/devicetype/DeviceTypeConfigurationManager.java
+++ b/components/common-api/org.wso2.carbon.device.mgt.common.impl/src/main/java/org/wso2/carbon/device/mgt/common/impl/config/devicetype/DeviceTypeConfigurationManager.java
@@ -87,6 +87,7 @@ public class DeviceTypeConfigurationManager {
 				}
 				deviceTypeConfigMap.put(iotDeviceTypeConfig.getType(), iotDeviceTypeConfig);
 			}
+			ApisAppClient.getInstance().setBase64EncodedConsumerKeyAndSecret(iotDeviceTypeConfigList);
 		} catch (Exception e) {
 			String error = "Error occurred while initializing device configurations";
 			log.error(error, e);


### PR DESCRIPTION
Reverts wso2/carbon-device-mgt#172
Actually, this is not the correct class which is to be changed. Correct class is in the carbon-device-mgt-plugins under components/device-mgt-iot/org.wso2.carbon.device.mgt.iot/src/main/java/org/wso2/carbon/device/mgt/iot/config/devicetype/ 
