### PR TITLE
Generalize Policy Implementation - Step 1

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroup.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroup.java
@@ -50,9 +50,8 @@ public class DeviceGroup implements Serializable {
 
     public DeviceGroup() {}
 
-    public DeviceGroup(String name, String description) {
+    public DeviceGroup(String name) {
         this.name = name;
-        this.description = description;
     }
 
     public int getGroupId() {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroup.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroup.java
@@ -48,6 +48,13 @@ public class DeviceGroup implements Serializable {
     private Long dateOfLastUpdate;
     private String owner;
 
+    public DeviceGroup() {}
+
+    public DeviceGroup(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
     public int getGroupId() {
         return id;
     }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroupConstants.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroupConstants.java
@@ -79,16 +79,4 @@ public class DeviceGroupConstants {
         public static final String[] DEFAULT_VIEW_EVENTS_PERMISSIONS =
                 {"/permission/device-mgt/user/groups/device_events"};
     }
-
-    /**
-     * Holds the constants related to default (System Generated) groups.
-     */
-    public static class DefaultGroups {
-        public static final String BYOD_GROUP_NAME = "BYOD";
-        public static final String BYOD_GROUP_DESCRIPTION = "This is the default group for BYOD (Bring Your Own Device)"
-                + " type devices.";
-        public static final String COPE_GROUP_NAME = "COPE";
-        public static final String COPE_GROUP_DESCRIPTION = "This is the default group for COPE (Corporate Owned) type"
-                + " devices.";
-    }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroupConstants.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/group/mgt/DeviceGroupConstants.java
@@ -79,4 +79,16 @@ public class DeviceGroupConstants {
         public static final String[] DEFAULT_VIEW_EVENTS_PERMISSIONS =
                 {"/permission/device-mgt/user/groups/device_events"};
     }
+
+    /**
+     * Holds the constants related to default (System Generated) groups.
+     */
+    public static class DefaultGroups {
+        public static final String BYOD_GROUP_NAME = "BYOD";
+        public static final String BYOD_GROUP_DESCRIPTION = "This is the default group for BYOD (Bring Your Own Device)"
+                + " type devices.";
+        public static final String COPE_GROUP_NAME = "COPE";
+        public static final String COPE_GROUP_DESCRIPTION = "This is the default group for COPE (Corporate Owned) type"
+                + " devices.";
+    }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/GroupManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/GroupManagementProviderService.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.device.mgt.common.group.mgt.GroupAlreadyExistException;
 import org.wso2.carbon.device.mgt.common.group.mgt.GroupManagementException;
 import org.wso2.carbon.device.mgt.common.group.mgt.GroupUser;
 import org.wso2.carbon.device.mgt.common.group.mgt.RoleDoesNotExistException;
+import org.wso2.carbon.device.mgt.core.dao.GroupManagementDAOException;
 import org.wso2.carbon.user.core.multiplecredentials.UserDoesNotExistException;
 
 import java.util.List;
@@ -75,6 +76,15 @@ public interface GroupManagementProviderService {
      * @throws GroupManagementException
      */
     DeviceGroup getGroup(int groupId) throws GroupManagementException;
+
+    /**
+     * Get the device group provided the device group id.
+     *
+     * @param groupName of the group.
+     * @return group with details.
+     * @throws GroupManagementException
+     */
+    DeviceGroup getGroup(String groupName) throws GroupManagementException;
 
     /**
      * Get all device groups in tenant.
@@ -212,14 +222,23 @@ public interface GroupManagementProviderService {
     int getDeviceCount(int groupId) throws GroupManagementException;
 
     /**
+     * @param groupId          of the group.
+     * @param deviceIdentifier of the device to add.
+     * @throws DeviceNotFoundException  If device does not exist.
+     * @throws GroupManagementException If unable to add device to the group.
+     */
+    void addDevice(int groupId, DeviceIdentifier deviceIdentifier)
+            throws DeviceNotFoundException, GroupManagementException;
+
+    /**
      * Add device to device group.
      *
-     * @param groupId   of the group.
+     * @param groupId           of the group.
      * @param deviceIdentifiers of devices.
      * @throws GroupManagementException
      */
-    void addDevices(int groupId, List<DeviceIdentifier> deviceIdentifiers) throws GroupManagementException,
-                                                                                  DeviceNotFoundException;
+    void addDevices(int groupId, List<DeviceIdentifier> deviceIdentifiers)
+            throws GroupManagementException, DeviceNotFoundException;
 
     /**
      * Remove device from device group.

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/GroupManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/GroupManagementProviderService.java
@@ -78,7 +78,7 @@ public interface GroupManagementProviderService {
     DeviceGroup getGroup(int groupId) throws GroupManagementException;
 
     /**
-     * Get the device group provided the device group id.
+     * Get the device group provided the device group name.
      *
      * @param groupName of the group.
      * @return group with details.


### PR DESCRIPTION
This PR is the first part of Generalizing Policy Implementation for WSO2 IoT.

This PR contains modifications done to create default system groups when enrolling mobile devices based on their ownership and assign the devices by default at the enrollment time.