### PR TITLE
IOTS-296: Removing ownership selection when policy creation

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.create/create.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.create/create.hbs
@@ -129,20 +129,6 @@
                                     <i class="icon fw fw-error"></i><span></span>
                                 </div>
                                 <div>
-                                    <label class="wr-input-label">
-                                        Set device ownership type
-                                    </label>
-                                    <div class="wr-input-control">
-                                        <div class="cus-col-50">
-                                            <!--suppress HtmlFormInputWithoutLabel -->
-                                            <select id="ownership-input" class="form-control">
-                                                <option value="ANY" selected>ANY</option>
-                                                <option value="BYOD">BYOD (Bring Your Own Device)</option>
-                                                <option value="COPE">COPE (Corporate-Owned, Personally Enabled)</option>
-                                            </select>
-                                        </div>
-                                        <br class="c-both"/>
-                                    </div>
                                     <div class="wr-input-control">
                                         {{#if isAuthorizedViewRoles}}
                                             <label class="wr-input-control radio light">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.create/public/js/policy-create.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.create/public/js/policy-create.js
@@ -201,12 +201,11 @@ stepForwardFrom["policy-criteria"] = function () {
         }
     });
     policy["selectedGroups"] = $("#groups-input").val();
-    if (policy["selectedGroups"].length > 1 || policy["selectedGroups"][0] !== "NONE") {
+    if (policy["selectedGroup"] && (policy["selectedGroups"].length > 1 || policy["selectedGroups"][0] !== "NONE")) {
         policy["selectedGroups"] = createDeviceGroupWrapper(policy["selectedGroups"]);
     }
 
     policy["selectedNonCompliantAction"] = $("#action-input").find(":selected").data("action");
-    policy["selectedOwnership"] = $("#ownership-input").val();
     //updating next-page wizard title with selected platform
     $("#policy-naming-page-wizard-title").text("ADD " + policy["platform"] + " POLICY");
 };
@@ -373,7 +372,7 @@ var savePolicy = function (policy, isActive, serviceURL) {
         "policyName": policy["policyName"],
         "description": policy["description"],
         "compliance": policy["selectedNonCompliantAction"],
-        "ownershipType": policy["selectedOwnership"],
+        "ownershipType": null,
         "active": isActive,
         "profile": {
             "profileName": policy["policyName"],

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.edit/edit.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.edit/edit.hbs
@@ -123,19 +123,6 @@
                                     <i class="icon fw fw-error"></i><span></span>
                                 </div>
                                 <div>
-                                    <label class="wr-input-label">
-                                        Set device ownership type
-                                    </label>
-                                    <div class="wr-input-control">
-                                        <div class="cus-col-50">
-                                            <select id="ownership-input" class="form-control">
-                                                <option value="ANY" selected>ANY</option>
-                                                <option value="BYOD">BYOD (Bring Your Own Device)</option>
-                                                <option value="COPE">COPE (Corporate-Owned, Personally Enabled)</option>
-                                            </select>
-                                        </div>
-                                        <br class="c-both"/>
-                                    </div>
                                     <div class="wr-input-control">
                                         {{#if isAuthorizedViewRoles}}
                                             <label class="wr-input-control radio light">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.edit/public/js/policy-edit.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.edit/public/js/policy-edit.js
@@ -425,7 +425,7 @@ var updatePolicy = function (policy, state) {
         "policyName": policy["policyName"],
         "description": policy["description"],
         "compliance": policy["selectedNonCompliantAction"],
-        "ownershipType": policy["selectedOwnership"],
+        "ownershipType": null,
         "profile": {
             "profileName": policy["policyName"],
             "deviceType": policy["platform"],


### PR DESCRIPTION
Removes ownership selection when creating and editing policies. Ownership management is done by the groups.