### PR TITLE
Moving error into common logic page.

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/app-conf.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/app-conf.json
@@ -40,7 +40,6 @@
         }
     },
     "errorPages": {
-        "404": "cdmf.page.error-404",
         "default": "uuf.page.error"
     }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/layouts/cdmf.layout.error.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/layouts/cdmf.layout.error.hbs
@@ -1,0 +1,48 @@
+{{!-- Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+WSO2 Inc. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License. --}}
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset='UTF-8'>
+    <link rel="stylesheet" href="https://error.cloud.wso2.com/style/style.css">
+    <link rel="stylesheet" href="https://error.cloud.wso2.com/style/font-mf.css">
+    <title>
+        {{defineZone "title"}}
+    </title>
+</head>
+<body>
+<div class="sky">
+    <section>
+        <div class="error-400">
+            <img src="https://error.cloud.wso2.com/images/400-error.svg">
+        </div>
+        <div class="text-label">
+            <h1>{{#defineZone "messageTitle"}}Oops something went wrong{{/defineZone}}</h1>
+            <h2>{{defineZone "messageDescription"}}</h2>
+            <div style="clear: both"></div>
+            <div class="button-label">
+                <a href="https://cloudmgt.cloud.wso2.com/cloudmgt/site/pages/index.jag"><label class="label-back">Back to Cloud </label></a>
+                <a href="https://cloudmgt.cloud.wso2.com/cloudmgt/site/pages/contact-us.jag"><label class="label-report"> Report Issue </label></a>
+            </div>
+        </div>
+    </section>
+
+    <div class="clouds_one"></div>
+    <div class="clouds_two"></div>
+    <div class="clouds_three"></div>
+</div>
+</body>
+</html>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.error-404/error-404.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.error-404/error-404.json
@@ -1,6 +1,0 @@
-{
-  "version": "1.0.0",
-  "uri": "/error/404",
-  "layout": "uuf.layout.default",
-  "isAnonymous": true
-}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.error/error.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.error/error.hbs
@@ -17,22 +17,6 @@
 }}
 {{#zone "title"}}Error | {{@app.conf.appName}}{{/zone}}
 
-{{#zone "breadcrumbs"}}
-    <li>
-        <a href="{{@app.context}}/">
-            <i class="icon fw fw-home"></i>
-        </a>
-    </li>
-{{/zone}}
-
-{{#zone "content"}}
-    <div class="message message-danger">
-        <h4><i class="icon fw fw-error"></i>An Error Occurred!</h4>
-
-        <div style="padding-left: 25px;">
-            <h5><b>HTTP Status : {{@page.params.status}}</b></h5>
-
-            <p style="white-space: pre-wrap;">{{@page.params.message}}</p>
-        </div>
-    </div>
+{{#zone "messageDescription"}}
+    {{@page.params.status}} - {{@page.params.message}}
 {{/zone}}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.error/error.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.error/error.json
@@ -1,0 +1,5 @@
+{
+    "version": "1.0.0",
+    "uri": "/errors/default",
+    "layout" : "cdmf.layout.error"
+}


### PR DESCRIPTION
If in cloud mode; change "default": "uuf.page.error" into "default": "cdmf.page.error" in app-conf.json