### PR TITLE
Revert "Allowing configuration management in cloud environment"

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
@@ -87,6 +87,7 @@
         <li><a href="{{@app.context}}/policies"><i class="fw fw-policy"></i>Policy Management</a></li>
     {{/if}}
 
+    {{#unless isCloud}}
     {{#if permissions.TENANT_CONFIGURATION}}
         <li><a><i class="fw fw-settings"></i>Configuration Management</a>
             <ul>
@@ -98,6 +99,9 @@
             </ul>
         </li>
     {{/if}}
+    {{/unless}}
+
+
 
 {{/zone}}
 


### PR DESCRIPTION
Reverts wso2/carbon-device-mgt#664. This change can't be passed to the cloud prod today. Hence reverting the changes.