### PR TITLE
Fix for disabling reboot and upgrade-firmware operations on UI

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/PolicyManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/PolicyManagementServiceImpl.java
@@ -345,11 +345,11 @@ public class PolicyManagementServiceImpl implements PolicyManagementService {
     public Response updatePolicyPriorities(List<PriorityUpdatedPolicyWrapper> priorityUpdatedPolicies) {
         PolicyManagerService policyManagementService = DeviceMgtAPIUtils.getPolicyManagementService();
         List<Policy> policiesToUpdate = new ArrayList<>(priorityUpdatedPolicies.size());
-        int i;
-        for (i = 0; i < priorityUpdatedPolicies.size(); i++) {
+
+        for (PriorityUpdatedPolicyWrapper priorityUpdatedPolicy : priorityUpdatedPolicies) {
             Policy policyObj = new Policy();
-            policyObj.setId(priorityUpdatedPolicies.get(i).getId());
-            policyObj.setPriorityId(priorityUpdatedPolicies.get(i).getPriority());
+            policyObj.setId(priorityUpdatedPolicy.getId());
+            policyObj.setPriorityId(priorityUpdatedPolicy.getPriority());
             policiesToUpdate.add(policyObj);
         }
         boolean policiesUpdated;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/modules/business-controllers/operation.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/modules/business-controllers/operation.js
@@ -86,6 +86,14 @@ var operationModule = function () {
             var iconIdentifier = operations[op].operation;
             if (features && features[iconIdentifier]) {
                 var icon = features[iconIdentifier].icon;
+                var isCloud = devicemgtProps["isCloud"];
+                //TODO: remove isCloud check once able to verify features from the device agent
+                var isDisabled = features[iconIdentifier].isDisabled;
+                if (isDisabled && isCloud) {
+                    operations[op]["isDisabled"] = isDisabled;
+                } else {
+                    operations[op]["isDisabled"] = false;
+                }
                 if (icon) {
                     operations[op]["iconFont"] = icon;
                 } else if (iconPath) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.theme/public/css/custom-common.css
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.theme/public/css/custom-common.css
@@ -266,3 +266,8 @@ header .username {
 .add-padding-top-3x {
     padding-top: 15px !important;
 }
+
+.op-disabled, .op-disabled i, .op-disabled span {
+    cursor: not-allowed;
++ color: #d2d2d2;
+}


### PR DESCRIPTION
+Code formatting

In order to execute these two operations the enrolled device needs to have the system app installed. Therefore, in order to stop users from trying these two operations on cloud, the icons related to these two operations, on operation bar are disabled. In addition change a c-style for loop to a foreach loop in PolicyManagementServiceImpl.java