### PR TITLE
Making geo location data publishing disabled on the default pack.

### DIFF
--- a/features/device-mgt/org.wso2.carbon.device.mgt.server.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/org.wso2.carbon.device.mgt.server.feature/src/main/resources/conf/cdm-config.xml
@@ -79,7 +79,7 @@
         <ExpiryTime>600</ExpiryTime>
     </DeviceCacheConfiguration>
     <GeoLocationConfiguration>
-        <PublishLocationOperationResponse>true</PublishLocationOperationResponse>
+        <PublishLocationOperationResponse>false</PublishLocationOperationResponse>
     </GeoLocationConfiguration>
 </DeviceMgtConfiguration>
 


### PR DESCRIPTION
Making <PublishLocationOperationResponse>false</PublishLocationOperationResponse> on the default pack.