### PR TITLE
fixing typo in the error message

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/devices.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/devices.hbs
@@ -497,7 +497,7 @@
                                 <div class="modal-content">
                                     <div class="row">
                                         <div class="col-lg-5 col-md-6 col-centered">
-                                            <h3>Please select one ore more devices in order to perform this
+                                            <h3>Please select one or more devices in order to perform this
                                                 operation.</h3>
                                             <br/>
                                             <div class="buttons">


### PR DESCRIPTION
Fixing the Typo found on device listing page