### PR TITLE
Fixed JWT properties reading issue

### DIFF
--- a/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/main/java/org/wso2/carbon/identity/jwt/client/extension/service/JWTClientManagerServiceImpl.java
+++ b/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/main/java/org/wso2/carbon/identity/jwt/client/extension/service/JWTClientManagerServiceImpl.java
@@ -103,11 +103,19 @@ public class JWTClientManagerServiceImpl implements JWTClientManagerService {
         if (defaultJWTClientMode != null && !defaultJWTClientMode.isEmpty()) {
             isDefaultJwtClient = Boolean.parseBoolean(defaultJWTClientMode);
         }
+        JWTConfig jwtConfig = new JWTConfig(properties);
         if (isDefaultJwtClient) {
             try {
-                JWTConfig jwtConfig = new JWTConfig(properties);
                 defaultJWTClient = new JWTClient(jwtConfig, true);
                 addJWTClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, defaultJWTClient);
+            } catch (JWTClientAlreadyExistsException e) {
+                log.warn("Attempting to register a default jwt client for the super tenant" +
+                        " when one already exists. Returning existing jwt client", e);
+            }
+        } else {
+            try {
+                JWTClient jwtClient = new JWTClient(jwtConfig);
+                addJWTClient(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, jwtClient);
             } catch (JWTClientAlreadyExistsException e) {
                 log.warn("Attempting to register a jwt client for the super tenant" +
                         " when one already exists. Returning existing jwt client", e);


### PR DESCRIPTION
Previously JWT properties file was read to get the defult-jwt-client properties. If someone wants to avoid reading the default keystores, it can only be done by uploading a jwt properties to registry and reading from itself.
This fix changes the default properties reading mechanism to get the properties from the file and creates a jwt client without being the default