### PR TITLE
Truncating applist version if length greater than allowed length

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/pom.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/pom.xml
@@ -158,6 +158,10 @@
                     <groupId>org.wso2.carbon.identity.framework</groupId>
                     <artifactId>org.wso2.carbon.user.mgt</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementConstants.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementConstants.java
@@ -87,6 +87,7 @@ public final class DeviceManagementConstants {
     public static final class OperationAttributes {
         private OperationAttributes() {throw new AssertionError(); }
         public static final String ACTIVITY = "ACTIVITY_";
+        public static final int APPLIST_VERSION_MAX_LENGTH = 50;
     }
 
     public static final class PushNotifications {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/app/mgt/ApplicationManagerProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/app/mgt/ApplicationManagerProviderServiceImpl.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.device.mgt.core.app.mgt;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.CarbonContext;
@@ -31,6 +32,7 @@ import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManagementException;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Activity;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManagementException;
+import org.wso2.carbon.device.mgt.core.DeviceManagementConstants;
 import org.wso2.carbon.device.mgt.core.app.mgt.config.AppManagementConfig;
 import org.wso2.carbon.device.mgt.core.dao.ApplicationDAO;
 import org.wso2.carbon.device.mgt.core.dao.ApplicationMappingDAO;
@@ -225,6 +227,14 @@ public class ApplicationManagerProviderServiceImpl implements ApplicationManagem
             List<Integer> applicationIds = new ArrayList<>();
 
             for (Application application : applications) {
+                /*
+                Truncating the application version if length of the version is greater than maximum allowed length.
+                 */
+                if (application.getVersion().length() >
+                        DeviceManagementConstants.OperationAttributes.APPLIST_VERSION_MAX_LENGTH) {
+                    application.setVersion(StringUtils.abbreviate(application.getVersion(),
+                            DeviceManagementConstants.OperationAttributes.APPLIST_VERSION_MAX_LENGTH));
+                }
                 if (!installedAppList.contains(application)) {
                     installedApp = applicationDAO.getApplication(application.getApplicationIdentifier(),
                             application.getVersion(), tenantId);


### PR DESCRIPTION
In this commit, the application version is truncated if the version length is greater than the maximum allowed length in the database level.