### PR TITLE
Fix for wso2/product-iots#1035

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/beans/BasicUserInfoWrapper.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/beans/BasicUserInfoWrapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.device.mgt.jaxrs.beans;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+@ApiModel(value = "BasicUserInfoWrapper", description = "This contains basic details of a set of users that matches " +
+        "a given criteria as a collection and a message if there's any.")
+public class BasicUserInfoWrapper {
+
+    @ApiModelProperty(
+            name = "basicUserInfo",
+            value = "Details of the User.",
+            required = true)
+    private BasicUserInfo basicUserInfo;
+
+    @ApiModelProperty(
+            name = "message",
+            value = "Response message if there's any.")
+    private String message;
+
+    public BasicUserInfo getBasicUserInfo() {
+        return basicUserInfo;
+    }
+
+    public void setBasicUserInfo(BasicUserInfo basicUserInfo) {
+        this.basicUserInfo = basicUserInfo;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
@@ -25,11 +25,13 @@ import org.eclipse.wst.common.uriresolver.internal.util.URIEncoder;
 import org.wso2.carbon.context.CarbonContext;
 import org.wso2.carbon.device.mgt.common.DeviceManagementException;
 import org.wso2.carbon.device.mgt.common.EnrolmentInfo;
+import org.wso2.carbon.device.mgt.common.configuration.mgt.ConfigurationManagementException;
 import org.wso2.carbon.device.mgt.core.DeviceManagementConstants;
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.device.mgt.core.service.EmailMetaInfo;
 import org.wso2.carbon.device.mgt.jaxrs.beans.BasicUserInfo;
 import org.wso2.carbon.device.mgt.jaxrs.beans.BasicUserInfoList;
+import org.wso2.carbon.device.mgt.jaxrs.beans.BasicUserInfoWrapper;
 import org.wso2.carbon.device.mgt.jaxrs.beans.EnrollmentInvitation;
 import org.wso2.carbon.device.mgt.jaxrs.beans.ErrorResponse;
 import org.wso2.carbon.device.mgt.jaxrs.beans.OldPasswordResetWrapper;
@@ -155,10 +157,19 @@ public class UserManagementServiceImpl implements UserManagementService {
             props.setProperty("password", initialUserPassword);
 
             EmailMetaInfo metaInfo = new EmailMetaInfo(recipient, props);
-            dms.sendRegistrationEmail(metaInfo);
+            BasicUserInfoWrapper userInfoWrapper = new BasicUserInfoWrapper();
+            String message;
+            try {
+                dms.sendRegistrationEmail(metaInfo);
+                message = "An invitation mail will be sent to this user to initiate device enrollment.";
+            } catch (ConfigurationManagementException e) {
+                message = "Mail Server is not configured. Email invitation will not be sent.";
+            }
+            userInfoWrapper.setBasicUserInfo(createdUserInfo);
+            userInfoWrapper.setMessage(message);
             return Response.created(new URI(API_BASE_PATH + "/" + URIEncoder.encode(userInfo.getUsername(), "UTF-8")))
                     .entity(
-                    createdUserInfo).build();
+                    userInfoWrapper).build();
         } catch (UserStoreException e) {
             String msg = "Error occurred while trying to add user '" + userInfo.getUsername() + "' to the " +
                     "underlying user management system";
@@ -573,6 +584,10 @@ public class UserManagementServiceImpl implements UserManagementService {
             log.error(msg, e);
             return Response.serverError().entity(
                     new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
+        } catch (ConfigurationManagementException e) {
+            String msg = "Error occurred while sending the email invitations. Mail server not configured.";
+            return Response.serverError().entity(
+                    new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
         }
         return Response.status(Response.Status.OK).entity("Invitation mails have been sent.").build();
     }
@@ -606,6 +621,10 @@ public class UserManagementServiceImpl implements UserManagementService {
         } catch (UserStoreException e) {
             String msg = "Error occurred while getting claim values to invite user";
             log.error(msg, e);
+            return Response.serverError().entity(
+                    new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
+        } catch (ConfigurationManagementException e) {
+            String msg = "Error occurred while sending the email invitations. Mail server not configured.";
             return Response.serverError().entity(
                     new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
         }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
@@ -572,7 +572,7 @@ public class UserManagementServiceImpl implements UserManagementService {
 
                 EmailMetaInfo metaInfo = new EmailMetaInfo(recipient, props);
                 dms.sendEnrolmentInvitation(DeviceManagementConstants.EmailAttributes.USER_ENROLLMENT_TEMPLATE,
-                                            metaInfo);
+                        metaInfo);
             }
         } catch (DeviceManagementException e) {
             String msg = "Error occurred while inviting user to enrol their device";

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
@@ -167,9 +167,8 @@ public class UserManagementServiceImpl implements UserManagementService {
             }
             userInfoWrapper.setBasicUserInfo(createdUserInfo);
             userInfoWrapper.setMessage(message);
-            return Response.created(new URI(API_BASE_PATH + "/" + URIEncoder.encode(userInfo.getUsername(), "UTF-8")))
-                    .entity(
-                    userInfoWrapper).build();
+            return Response.created(new URI(API_BASE_PATH + "/" + URIEncoder.encode(userInfo.getUsername(),
+                    "UTF-8"))).entity(userInfoWrapper).build();
         } catch (UserStoreException e) {
             String msg = "Error occurred while trying to add user '" + userInfo.getUsername() + "' to the " +
                     "underlying user management system";
@@ -189,8 +188,7 @@ public class UserManagementServiceImpl implements UserManagementService {
             return Response.serverError().entity(
                     new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
         } catch (DeviceManagementException e) {
-            String msg = "Error occurred while sending registration email to the user " +
-                    userInfo.getUsername();
+            String msg = "Error occurred while sending registration email to the user " + userInfo.getUsername();
             log.error(msg, e);
             return Response.serverError().entity(
                     new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.device.mgt.common.InvalidDeviceException;
 import org.wso2.carbon.device.mgt.common.MonitoringOperation;
 import org.wso2.carbon.device.mgt.common.PaginationRequest;
 import org.wso2.carbon.device.mgt.common.PaginationResult;
+import org.wso2.carbon.device.mgt.common.configuration.mgt.ConfigurationManagementException;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.PlatformConfiguration;
 import org.wso2.carbon.device.mgt.common.license.mgt.License;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Activity;
@@ -436,9 +437,10 @@ public interface DeviceManagementProviderService {
 
     HashMap<Integer, Device> getTenantedDevice(DeviceIdentifier deviceIdentifier) throws DeviceManagementException;
 
-    void sendEnrolmentInvitation(String templateName, EmailMetaInfo metaInfo) throws DeviceManagementException;
+    void sendEnrolmentInvitation(String templateName, EmailMetaInfo metaInfo) throws DeviceManagementException,
+            ConfigurationManagementException;
 
-    void sendRegistrationEmail(EmailMetaInfo metaInfo) throws DeviceManagementException;
+    void sendRegistrationEmail(EmailMetaInfo metaInfo) throws DeviceManagementException, ConfigurationManagementException;
 
     FeatureManager getFeatureManager(String deviceType) throws DeviceManagementException;
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.user.create/create.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.user.create/create.hbs
@@ -131,6 +131,11 @@
                         An invitation mail will be sent to this user to initiate device enrollment.
                     </h4>
                 </div>
+                <div id="modal-content-user-created-with-message" class="hide">
+                    <div id="notification-error-msg" class="alert alert-danger hidden" role="alert">
+                        <i class="icon fw fw-error"></i><span></span>
+                    </div>
+                </div>
                 <!-- /content -->
             </div>
         </div>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.user.create/create.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.user.create/create.hbs
@@ -128,7 +128,7 @@
                         <i class="icon fw fw-error"></i><span></span>
                     </div>
                     <h4>
-                        User added successfully.
+                        An invitation mail will be sent to this user to initiate device enrollment.
                     </h4>
                 </div>
                 <div id="modal-content-user-created-with-message" class="hide">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.user.create/public/js/bottomJs.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.user.create/public/js/bottomJs.js
@@ -272,6 +272,7 @@ $(document).ready(function () {
                 addUserFormData,
                 function (data, textStatus, jqXHR) {
                     if (jqXHR.status == 201) {
+                        var response = JSON.parse(data);
                         // Clearing user input fields.
                         $("input#username").val("");
                         $("input#firstname").val("");
@@ -284,7 +285,12 @@ $(document).ready(function () {
                         $("#user-create-form").addClass("hidden");
                         modalDialog.header('<span class="fw-stack">' +
                             '<i class="fw fw-info fw-stack-1x"></i> </span> User was added successfully');
-                        modalDialog.content($("#modal-content-user-created").html());
+                        if (response.message) {
+                            $("#modal-content-user-created-with-message").append("<h4>" + response.message + "</h4>");
+                            modalDialog.content($("#modal-content-user-created-with-message").html());
+                        } else {
+                            modalDialog.content($("#modal-content-user-created").html());
+                        }
                         modalDialog.footer('<div class="buttons"> ' +
                             '<a href="/devicemgt/users" id="reset-password-yes-link" class="btn-operations"> OK' +
                             '</a></div>');

--- a/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/EmailTransportNotConfiguredException.java
+++ b/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/EmailTransportNotConfiguredException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.email.sender.core;
+
+public class EmailTransportNotConfiguredException extends Exception {
+
+    private static final long serialVersionUID = -3151279311929070294L;
+
+    public EmailTransportNotConfiguredException(String msg, Exception nestedEx) {
+        super(msg, nestedEx);
+    }
+
+    public EmailTransportNotConfiguredException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EmailTransportNotConfiguredException(String msg) {
+        super(msg);
+    }
+
+    public EmailTransportNotConfiguredException() {
+        super();
+    }
+
+    public EmailTransportNotConfiguredException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/service/EmailSenderService.java
+++ b/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/service/EmailSenderService.java
@@ -19,9 +19,10 @@ package org.wso2.carbon.email.sender.core.service;
 
 import org.wso2.carbon.email.sender.core.EmailContext;
 import org.wso2.carbon.email.sender.core.EmailSendingFailedException;
+import org.wso2.carbon.email.sender.core.EmailTransportNotConfiguredException;
 
 public interface EmailSenderService {
 
-    void sendEmail(EmailContext emailCtx) throws EmailSendingFailedException;
+    void sendEmail(EmailContext emailCtx) throws EmailSendingFailedException, EmailTransportNotConfiguredException;
 
 }

--- a/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/service/EmailSenderServiceImpl.java
+++ b/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/service/EmailSenderServiceImpl.java
@@ -62,12 +62,8 @@ public class EmailSenderServiceImpl implements EmailSenderService {
     }
 
     private boolean isMailServerConfigured() {
-        if(EmailSenderDataHolder.getInstance().getConfigurationContextService().getServerConfigContext().
-                getAxisConfiguration().getTransportOut(TRANSPORT_SENDER_NAME) != null) {
-            return true;
-        } else {
-            return false;
-        }
+        return (EmailSenderDataHolder.getInstance().getConfigurationContextService().getServerConfigContext().
+                getAxisConfiguration().getTransportOut(TRANSPORT_SENDER_NAME) != null);
     }
 
     @Override

--- a/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/service/EmailSenderServiceImpl.java
+++ b/components/email-sender/org.wso2.carbon.email.sender.core/src/main/java/org/wso2/carbon/email/sender/core/service/EmailSenderServiceImpl.java
@@ -62,8 +62,8 @@ public class EmailSenderServiceImpl implements EmailSenderService {
     }
 
     private boolean isMailServerConfigured() {
-        if(EmailSenderDataHolder.getInstance().getConfigurationContextService()
-                .getServerConfigContext().getAxisConfiguration().getTransportOut(TRANSPORT_SENDER_NAME) != null) {
+        if(EmailSenderDataHolder.getInstance().getConfigurationContextService().getServerConfigContext().
+                getAxisConfiguration().getTransportOut(TRANSPORT_SENDER_NAME) != null) {
             return true;
         } else {
             return false;
@@ -141,7 +141,5 @@ public class EmailSenderServiceImpl implements EmailSenderService {
                         "'", e);
             }
         }
-
     }
-
 }


### PR DESCRIPTION
This includes the fix and some minor refactoring work. With this fix the user will be prompted with a message 'Mail Server is not configured. Email invitation will not be sent' if **mailto** sender transport is not configured. Also there will be a warn log in the server log if it's not configured. As a result of this enhancement POST users/ response has been modified as below. **message** property will include both success and failure messages.

{
    "basicUserInfo" : {
              "username":"PRIMARY/username123",
              "firstname":"userfirstname",
              "lastname":"userlastname",
               "emailAddress":"user123@gmail.com" 
    },
    "message":"Mail Server is not configured. Email invitation will not be sent."
}
