### PR TITLE
Adding the certificate caching to improve performance

### DIFF
--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/pom.xml
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/pom.xml
@@ -94,6 +94,7 @@
                             io.swagger.annotations.*;resolution:=optional,
                             org.wso2.carbon.device.mgt.core.*,
                             org.wso2.carbon.registry.indexing.*,
+                            javax.cache.*
                             <!--org.bouncycastle.pkcs.jcajce-->
                         </Import-Package>
                         <Export-Package>

--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/cache/CertificateCacheManager.java
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/cache/CertificateCacheManager.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.carbon.certificate.mgt.core.cache;
+
+import org.wso2.carbon.certificate.mgt.core.dto.CertificateResponse;
+
+/**
+ * This interface for caching the certificates.
+ */
+
+public interface CertificateCacheManager {
+
+    void addCertificateBySerial(String serialNumber, CertificateResponse certificate) ;
+
+    void addCertificateByCN(String commonName, CertificateResponse certificate) ;
+
+    CertificateResponse getCertificateBySerial(String serialNumber) ;
+
+    CertificateResponse getCertificateByCN(String commonName) ;
+
+}
+

--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/cache/impl/CertificateCacheManagerImpl.java
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/cache/impl/CertificateCacheManagerImpl.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.carbon.certificate.mgt.core.cache.impl;
+
+import org.wso2.carbon.certificate.mgt.core.cache.CertificateCacheManager;
+import org.wso2.carbon.certificate.mgt.core.dto.CertificateResponse;
+import org.wso2.carbon.device.mgt.core.config.DeviceConfigurationManager;
+import org.wso2.carbon.device.mgt.core.config.DeviceManagementConfig;
+
+import javax.cache.Cache;
+import javax.cache.CacheConfiguration;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import java.util.concurrent.TimeUnit;
+
+public class CertificateCacheManagerImpl implements CertificateCacheManager {
+
+    public static final String CERTIFICATE_CACHE_MANAGER = "CERTIFICATE_CACHE_MANAGER";
+    public static final String CERTIFICATE_CACHE = "CERTIFICATE_CACHE";
+    private static boolean isCertificateCacheInitialized = false;
+    private static String SERIAL_PRE = "S_";
+    private static String COMMON_NAME_PRE = "C_";
+
+    private static CertificateCacheManager certificateCacheManager;
+
+
+    private CertificateCacheManagerImpl() {
+    }
+
+    public static CertificateCacheManager getInstance() {
+        if (certificateCacheManager == null) {
+            synchronized (CertificateCacheManagerImpl.class) {
+                if (certificateCacheManager == null) {
+                    certificateCacheManager = new CertificateCacheManagerImpl();
+                }
+            }
+        }
+        return certificateCacheManager;
+    }
+
+    @Override
+    public void addCertificateBySerial(String serialNumber, CertificateResponse certificate) {
+        CertificateCacheManagerImpl.getCertificateCache().put(SERIAL_PRE + serialNumber, certificate);
+    }
+
+    @Override
+    public void addCertificateByCN(String commonName, CertificateResponse certificate) {
+        CertificateCacheManagerImpl.getCertificateCache().put(COMMON_NAME_PRE + commonName, certificate);
+    }
+
+    @Override
+    public CertificateResponse getCertificateBySerial(String serialNumber) {
+        return CertificateCacheManagerImpl.getCertificateCache().get(SERIAL_PRE + serialNumber);
+    }
+
+    @Override
+    public CertificateResponse getCertificateByCN(String commonName) {
+        return CertificateCacheManagerImpl.getCertificateCache().get(COMMON_NAME_PRE + commonName);
+    }
+
+
+    private static CacheManager getCacheManager() {
+        return Caching.getCacheManagerFactory().getCacheManager(CertificateCacheManagerImpl.CERTIFICATE_CACHE_MANAGER);
+    }
+
+    public static Cache<String, CertificateResponse> getCertificateCache() {
+        DeviceManagementConfig config = DeviceConfigurationManager.getInstance().getDeviceManagementConfig();
+        CacheManager manager = getCacheManager();
+        Cache<String, CertificateResponse> certificateCache = null;
+        if (config.getDeviceCacheConfiguration().isEnabled()) {
+            if (!isCertificateCacheInitialized) {
+                initializeCertificateCache();
+            }
+            if (manager != null) {
+                certificateCache = manager.<String, CertificateResponse>getCache(CertificateCacheManagerImpl.CERTIFICATE_CACHE);
+            } else {
+                certificateCache = Caching.getCacheManager(CertificateCacheManagerImpl.CERTIFICATE_CACHE_MANAGER).
+                        <String, CertificateResponse>getCache(CertificateCacheManagerImpl.CERTIFICATE_CACHE);
+            }
+        }
+        return certificateCache;
+    }
+
+    public static void initializeCertificateCache() {
+        DeviceManagementConfig config = DeviceConfigurationManager.getInstance().getDeviceManagementConfig();
+        int certificateCacheExpiry = config.getCertificateCacheConfiguration().getExpiryTime();
+        CacheManager manager = getCacheManager();
+        if (config.getCertificateCacheConfiguration().isEnabled()) {
+            if (!isCertificateCacheInitialized) {
+                isCertificateCacheInitialized = true;
+                if (manager != null) {
+                    if (certificateCacheExpiry > 0) {
+                        manager.<String, CertificateResponse>createCacheBuilder(CertificateCacheManagerImpl.CERTIFICATE_CACHE).
+                                setExpiry(CacheConfiguration.ExpiryType.MODIFIED, new CacheConfiguration.Duration(TimeUnit.SECONDS,
+                                        certificateCacheExpiry)).setExpiry(CacheConfiguration.ExpiryType.ACCESSED, new CacheConfiguration.
+                                Duration(TimeUnit.SECONDS, certificateCacheExpiry)).setStoreByValue(true).build();
+                    } else {
+                        manager.<String, CertificateResponse>getCache(CertificateCacheManagerImpl.CERTIFICATE_CACHE);
+                    }
+                } else {
+                    if (certificateCacheExpiry > 0) {
+                        Caching.getCacheManager().
+                                <String, CertificateResponse>createCacheBuilder(CertificateCacheManagerImpl.CERTIFICATE_CACHE).
+                                setExpiry(CacheConfiguration.ExpiryType.MODIFIED, new CacheConfiguration.Duration(TimeUnit.SECONDS,
+                                        certificateCacheExpiry)).setExpiry(CacheConfiguration.ExpiryType.ACCESSED, new CacheConfiguration.
+                                Duration(TimeUnit.SECONDS, certificateCacheExpiry)).setStoreByValue(true).build();
+                    } else {
+                        Caching.getCacheManager().<String, CertificateResponse>getCache(CertificateCacheManagerImpl.CERTIFICATE_CACHE);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/config/DeviceManagementConfig.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/config/DeviceManagementConfig.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.carbon.device.mgt.core.config;
 
+import org.wso2.carbon.device.mgt.core.config.cache.CertificateCacheConfiguration;
 import org.wso2.carbon.device.mgt.core.config.geo.location.GeoLocationConfiguration;
 import org.wso2.carbon.device.mgt.core.config.cache.DeviceCacheConfiguration;
 import org.wso2.carbon.device.mgt.core.config.identity.IdentityConfigurations;
@@ -46,6 +47,7 @@ public final class DeviceManagementConfig {
     private PullNotificationConfiguration pullNotificationConfiguration;
     private DeviceStatusTaskConfig deviceStatusTaskConfig;
     private DeviceCacheConfiguration deviceCacheConfiguration;
+    private CertificateCacheConfiguration certificateCacheConfiguration;
     private GeoLocationConfiguration geoLocationConfiguration;
     private String defaultGroupsConfiguration;
 
@@ -129,6 +131,15 @@ public final class DeviceManagementConfig {
 
     public void setDeviceCacheConfiguration(DeviceCacheConfiguration deviceCacheConfiguration) {
         this.deviceCacheConfiguration = deviceCacheConfiguration;
+    }
+
+    @XmlElement(name = "CertificateCacheConfiguration", required = true)
+    public CertificateCacheConfiguration getCertificateCacheConfiguration() {
+        return certificateCacheConfiguration;
+    }
+
+    public void setCertificateCacheConfiguration(CertificateCacheConfiguration certificateCacheConfiguration) {
+        this.certificateCacheConfiguration = certificateCacheConfiguration;
     }
 
     @XmlElement(name = "GeoLocationConfiguration", required = true)

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/config/cache/CertificateCacheConfiguration.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/config/cache/CertificateCacheConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.device.mgt.core.config.cache;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "CertificateCacheConfiguration")
+public class CertificateCacheConfiguration {
+
+    private boolean isEnabled;
+    private int expiryTime;
+
+    @XmlElement(name = "Enable", required = true)
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        isEnabled = enabled;
+    }
+
+    @XmlElement(name = "ExpiryTime", required = true)
+    public int getExpiryTime() {
+        return expiryTime;
+    }
+
+    public void setExpiryTime(int expiryTime) {
+        this.expiryTime = expiryTime;
+    }
+}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/util/DeviceManagerUtil.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/util/DeviceManagerUtil.java
@@ -76,7 +76,7 @@ public final class DeviceManagerUtil {
 
     private static final Log log = LogFactory.getLog(DeviceManagerUtil.class);
 
-    private  static boolean isDeviceCacheInistialized = false;
+    private  static boolean isDeviceCacheInitialized = false;
 
     public static Document convertToDocument(File file) throws DeviceManagementException {
         DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -494,8 +494,8 @@ public final class DeviceManagerUtil {
         int deviceCacheExpiry = config.getDeviceCacheConfiguration().getExpiryTime();
         CacheManager manager = getCacheManager();
         if (config.getDeviceCacheConfiguration().isEnabled()) {
-            if(!isDeviceCacheInistialized) {
-                isDeviceCacheInistialized = true;
+            if(!isDeviceCacheInitialized) {
+                isDeviceCacheInitialized = true;
                 if (manager != null) {
                     if (deviceCacheExpiry > 0) {
                         manager.<DeviceCacheKey, Device>createCacheBuilder(DeviceManagementConstants.DEVICE_CACHE).
@@ -525,7 +525,7 @@ public final class DeviceManagerUtil {
         CacheManager manager = getCacheManager();
         Cache<DeviceCacheKey, Device> deviceCache = null;
         if (config.getDeviceCacheConfiguration().isEnabled()) {
-            if(!isDeviceCacheInistialized) {
+            if(!isDeviceCacheInitialized) {
                 initializeDeviceCache();
             }
             if (manager != null) {

--- a/features/device-mgt/org.wso2.carbon.device.mgt.server.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/org.wso2.carbon.device.mgt.server.feature/src/main/resources/conf/cdm-config.xml
@@ -78,6 +78,10 @@
         <Enable>true</Enable>
         <ExpiryTime>600</ExpiryTime>
     </DeviceCacheConfiguration>
+    <CertificateCacheConfiguration>
+        <Enable>true</Enable>
+        <ExpiryTime>86400</ExpiryTime>
+    </CertificateCacheConfiguration>
     <GeoLocationConfiguration>
         <isEnabled>false</isEnabled>
         <PublishLocationOperationResponse>false</PublishLocationOperationResponse>


### PR DESCRIPTION
This fix improves the device authentication using mutual SSL certificates. SSL certificates are stored in IoT server database. Before the fix, every time device sends a request, it is validated against the database. This fix adds caching layer before the database.

Following configurations is added to cdm-config.xml. The "Enable" is set to true for engaging and false for disengaging. The "ExpiryTime" is to set the time when cache should be expired. By default, it is set to a one day. It is ok for this to set a higher value because certificates expiry time is longer such as 3 months to a number of years.

    <CertificateCacheConfiguration>
        <Enable>true</Enable>
        <ExpiryTime>86400</ExpiryTime>
    </CertificateCacheConfiguration>

