### PR TITLE
Adding more testcases for analytics data publisher

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/pom.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/pom.xml
@@ -78,6 +78,10 @@
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.securevault</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.sling</groupId>
+            <artifactId>org.apache.sling.testing.osgi-mock</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherConfigTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherConfigTest.java
@@ -79,4 +79,5 @@ public class DataPublisherConfigTest extends BaseAnalyticsDataPublisherTest {
         Assert.assertEquals(analyticsConfiguration.getReceiverServerUrl(), "tcp://localhost:7615");
         Assert.assertTrue(analyticsConfiguration.isEnable());
     }
+
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherServiceComponentTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherServiceComponentTest.java
@@ -28,6 +28,9 @@ import org.wso2.carbon.device.mgt.analytics.data.publisher.util.TestComponentCon
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+/**
+ * This tesclass will be validating the behaviour of {@link DataPublisherServiceComponent}
+ */
 public class DataPublisherServiceComponentTest extends BaseAnalyticsDataPublisherTest {
     private DataPublisherServiceComponent serviceComponent;
 
@@ -36,17 +39,17 @@ public class DataPublisherServiceComponentTest extends BaseAnalyticsDataPublishe
         this.serviceComponent = new DataPublisherServiceComponent();
     }
 
-    @Test
+    @Test (description = "Test bundle activation with exception thrown when service resgistration")
     public void activateWithException() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         this.activate(new TestComponentContext());
     }
 
-    @Test(dependsOnMethods = "activateWithException")
+    @Test(dependsOnMethods = "activateWithException", description = "Test the bundle activation with succesful path")
     public void activateWithoutException() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         this.activate(MockOsgi.newComponentContext());
     }
 
-    @Test(dependsOnMethods = "activateWithoutException")
+    @Test(dependsOnMethods = "activateWithoutException", description = "Test bundle deactivation")
     public void deActivate() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
         Method method = this.serviceComponent.getClass().getDeclaredMethod("deactivate", ComponentContext.class);
         method.setAccessible(true);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherServiceComponentTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherServiceComponentTest.java
@@ -40,12 +40,14 @@ public class DataPublisherServiceComponentTest extends BaseAnalyticsDataPublishe
     }
 
     @Test (description = "Test bundle activation with exception thrown when service resgistration")
-    public void activateWithException() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    public void activateWithException() throws NoSuchMethodException, IllegalAccessException,
+            InvocationTargetException {
         this.activate(new TestComponentContext());
     }
 
     @Test(dependsOnMethods = "activateWithException", description = "Test the bundle activation with succesful path")
-    public void activateWithoutException() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    public void activateWithoutException() throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
         this.activate(MockOsgi.newComponentContext());
     }
 
@@ -56,7 +58,8 @@ public class DataPublisherServiceComponentTest extends BaseAnalyticsDataPublishe
         method.invoke(this.serviceComponent, MockOsgi.newComponentContext());
     }
 
-    private void activate(ComponentContext componentContext) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    private void activate(ComponentContext componentContext) throws NoSuchMethodException, InvocationTargetException,
+            IllegalAccessException {
         Method method = this.serviceComponent.getClass().getDeclaredMethod("activate", ComponentContext.class);
         method.setAccessible(true);
         method.invoke(this.serviceComponent, componentContext);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherServiceComponentTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/DataPublisherServiceComponentTest.java
@@ -1,0 +1,61 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*/
+package org.wso2.carbon.device.mgt.analytics.data.publisher;
+
+
+import org.apache.sling.testing.mock.osgi.MockOsgi;
+import org.osgi.service.component.ComponentContext;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.device.mgt.analytics.data.publisher.internal.DataPublisherServiceComponent;
+import org.wso2.carbon.device.mgt.analytics.data.publisher.util.TestComponentContext;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class DataPublisherServiceComponentTest extends BaseAnalyticsDataPublisherTest {
+    private DataPublisherServiceComponent serviceComponent;
+
+    @BeforeClass
+    public void initTest() {
+        this.serviceComponent = new DataPublisherServiceComponent();
+    }
+
+    @Test
+    public void activateWithException() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        this.activate(new TestComponentContext());
+    }
+
+    @Test(dependsOnMethods = "activateWithException")
+    public void activateWithoutException() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        this.activate(MockOsgi.newComponentContext());
+    }
+
+    @Test(dependsOnMethods = "activateWithoutException")
+    public void deActivate() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = this.serviceComponent.getClass().getDeclaredMethod("deactivate", ComponentContext.class);
+        method.setAccessible(true);
+        method.invoke(this.serviceComponent, MockOsgi.newComponentContext());
+    }
+
+    private void activate(ComponentContext componentContext) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = this.serviceComponent.getClass().getDeclaredMethod("activate", ComponentContext.class);
+        method.setAccessible(true);
+        method.invoke(this.serviceComponent, componentContext);
+    }
+}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/EventPublisherServiceTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/EventPublisherServiceTest.java
@@ -29,9 +29,7 @@ import org.wso2.carbon.device.mgt.analytics.data.publisher.exception.DataPublish
 import org.wso2.carbon.device.mgt.analytics.data.publisher.service.EventsPublisherService;
 import org.wso2.carbon.device.mgt.analytics.data.publisher.service.EventsPublisherServiceImpl;
 
-import java.io.File;
 import java.lang.reflect.Field;
-import java.net.URL;
 
 /**
  * This test class will test the methods that are exposed from {@link EventsPublisherService}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/util/TestComponentContext.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/util/TestComponentContext.java
@@ -1,0 +1,78 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+*/
+package org.wso2.carbon.device.mgt.analytics.data.publisher.util;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.ComponentInstance;
+
+import java.util.Dictionary;
+
+public class TestComponentContext implements ComponentContext {
+    @Override
+    public Dictionary getProperties() {
+        return null;
+    }
+
+    @Override
+    public Object locateService(String s) {
+        return null;
+    }
+
+    @Override
+    public Object locateService(String s, ServiceReference serviceReference) {
+        return null;
+    }
+
+    @Override
+    public Object[] locateServices(String s) {
+        return new Object[0];
+    }
+
+    @Override
+    public BundleContext getBundleContext() {
+        return null;
+    }
+
+    @Override
+    public Bundle getUsingBundle() {
+        return null;
+    }
+
+    @Override
+    public ComponentInstance getComponentInstance() {
+        return null;
+    }
+
+    @Override
+    public void enableComponent(String s) {
+
+    }
+
+    @Override
+    public void disableComponent(String s) {
+
+    }
+
+    @Override
+    public ServiceReference getServiceReference() {
+        return null;
+    }
+}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/util/TestComponentContext.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/java/org/wso2/carbon/device/mgt/analytics/data/publisher/util/TestComponentContext.java
@@ -25,6 +25,9 @@ import org.osgi.service.component.ComponentInstance;
 
 import java.util.Dictionary;
 
+/**
+ * Mock implementation for component context.
+ */
 public class TestComponentContext implements ComponentContext {
     @Override
     public Dictionary getProperties() {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/resources/testng.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.analytics.data.publisher/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
         <classes>
             <class name="org.wso2.carbon.device.mgt.analytics.data.publisher.DataPublisherConfigTest"/>
             <class name="org.wso2.carbon.device.mgt.analytics.data.publisher.EventPublisherServiceTest"/>
+            <class name="org.wso2.carbon.device.mgt.analytics.data.publisher.DataPublisherServiceComponentTest"/>
         </classes>
     </test>
 </suite>

--- a/components/test-coverage/pom.xml
+++ b/components/test-coverage/pom.xml
@@ -180,6 +180,9 @@
                                                 <fileset dir="${device.mgt.extensions}/${target}/${coverge-report}">
                                                     <include name="${individual.test.report.name}" />
                                                 </fileset>
+                                                <fileset dir="${device.mgt.analytics.data}/${target}/${coverge-report}">
+                                                    <include name="${individual.test.report.name}" />
+                                                </fileset>
 
                                                 <!-- Need to list the newly added exec files here -->
                                             </executiondata>

--- a/pom.xml
+++ b/pom.xml
@@ -409,6 +409,12 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.sling</groupId>
+                <artifactId>org.apache.sling.testing.osgi-mock</artifactId>
+                <version>${apache.osgi.mock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.governance</groupId>
                 <artifactId>org.wso2.carbon.governance.api</artifactId>
                 <version>${carbon.governance.version}</version>
@@ -1968,6 +1974,9 @@
 
         <!-- apache pdfbox version -->
         <slf4j.simple.version>1.6.1</slf4j.simple.version>
+
+        <!--apache osgi mock version-->
+        <apache.osgi.mock.version>2.3.2</apache.osgi.mock.version>
 
         <!-- api-mgt handler version properties -->
         <org.apache.synapse.version>2.1.7-wso2v7</org.apache.synapse.version>


### PR DESCRIPTION
## Purpose
More testcases for the analytics data publisher component. 

## Goals
Improve the code coverage. 

## Approach
I have used the Mock Osgi to mock the osgi service component activate and deactivate methods.
