### PR TITLE
This commit fixes the unable to parse the DN issue

### DIFF
--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/impl/CertificateGenerator.java
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/impl/CertificateGenerator.java
@@ -323,19 +323,25 @@ public class CertificateGenerator {
         CertificateResponse lookUpCertificate = null;
         KeyStoreReader keyStoreReader = new KeyStoreReader();
         if (distinguishedName != null && !distinguishedName.isEmpty()) {
-            LdapName ldapName;
-            try {
-                ldapName = new LdapName(distinguishedName);
-            } catch (InvalidNameException e) {
-                throw new KeystoreException(
-                        "Invalid name exception while trying to create a LDAP name using the distinguished name ", e);
-            }
-            for (Rdn relativeDistinuguishedNames : ldapName.getRdns()) {
-                if (relativeDistinuguishedNames.getType().equalsIgnoreCase("CN")) {
-                    System.err.println("CN is: " + relativeDistinuguishedNames.getValue());
-                    lookUpCertificate = keyStoreReader
-                            .getCertificateBySerial(String.valueOf(relativeDistinuguishedNames.getValue()));
-                    break;
+            if (distinguishedName.contains("/CN=")) {
+                String[] dnSplits = distinguishedName.split("/CN=");
+                String commonNameExtracted = dnSplits[dnSplits.length - 1];
+                lookUpCertificate = keyStoreReader.getCertificateBySerial(commonNameExtracted);
+            } else {
+                LdapName ldapName;
+                try {
+                    ldapName = new LdapName(distinguishedName);
+                } catch (InvalidNameException e) {
+                    throw new KeystoreException(
+                            "Invalid name exception while trying to create a LDAP name using the distinguished name ",
+                            e);
+                }
+                for (Rdn relativeDistinguishedNames : ldapName.getRdns()) {
+                    if (relativeDistinguishedNames.getType().equalsIgnoreCase("CN")) {
+                        lookUpCertificate = keyStoreReader
+                                .getCertificateBySerial(String.valueOf(relativeDistinguishedNames.getValue()));
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Purpose
> Currently when a DN cannot be parsed if the DN is not in RFC2253 format. This PR fixes this issue.

## Goals
> This PR will treat the two standards separately.