### PR TITLE
Fixing the build failure for the SNAPSHOT dependency

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.devicetype.api/pom.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.devicetype.api/pom.xml
@@ -78,14 +78,14 @@
     </dependencies>
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.wso2.maven.plugins</groupId>
-                <artifactId>swagger2msf4j-maven-plugin</artifactId>
-                <version>1.0-SNAPSHOT</version>
-                <configuration>
-                    <inputSpec>${project.basedir}/src/main/resources/admin-device-types-api.yaml</inputSpec>
-                </configuration>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>org.wso2.maven.plugins</groupId>-->
+                <!--<artifactId>swagger2msf4j-maven-plugin</artifactId>-->
+                <!--<version>1.0-SNAPSHOT</version>-->
+                <!--<configuration>-->
+                    <!--<inputSpec>${project.basedir}/src/main/resources/admin-device-types-api.yaml</inputSpec>-->
+                <!--</configuration>-->
+            <!--</plugin>-->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
## Purpose
> Fixing the build failure due to the snapshot dependency of the maven msf4j-swagger-codegen plugin