### PR TITLE
Unit Tests for getGeoDevicesLocations API

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -81,7 +81,7 @@
     <bean id="roleManagementService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.RoleManagementServiceImpl"/>
     <bean id="userManagementService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.UserManagementServiceImpl"/>
     <bean id="groupManagementService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.GroupManagementServiceImpl"/>
-    <bean id="geoService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.GeoLocationBasedServiceImpl"/>
+    <bean id="geoService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.GeoLocationBasedServiceImplTest"/>
     <bean id="remoteSessionService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.RemoteSessionServiceImpl"/>
     <bean id="deviceManagementAdminService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.admin.DeviceManagementAdminServiceImpl"/>
     <bean id="applicationManagementAdminService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.admin.ApplicationManagementAdminServiceImpl"/>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/webapp/WEB-INF/cxf-servlet.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/webapp/WEB-INF/cxf-servlet.xml
@@ -81,7 +81,7 @@
     <bean id="roleManagementService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.RoleManagementServiceImpl"/>
     <bean id="userManagementService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.UserManagementServiceImpl"/>
     <bean id="groupManagementService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.GroupManagementServiceImpl"/>
-    <bean id="geoService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.GeoLocationBasedServiceImplTest"/>
+    <bean id="geoService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.GeoLocationBasedServiceImpl"/>
     <bean id="remoteSessionService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.RemoteSessionServiceImpl"/>
     <bean id="deviceManagementAdminService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.admin.DeviceManagementAdminServiceImpl"/>
     <bean id="applicationManagementAdminService" class="org.wso2.carbon.device.mgt.jaxrs.service.impl.admin.ApplicationManagementAdminServiceImpl"/>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/GeoLocationBasedServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/GeoLocationBasedServiceImplTest.java
@@ -3,24 +3,14 @@ package org.wso2.carbon.device.mgt.jaxrs.service.impl;
 
 import org.mockito.Mockito;
 import org.testng.Assert;
-import org.testng.IObjectFactory;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.ObjectFactory;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.device.mgt.common.DeviceManagementException;
-import org.wso2.carbon.device.mgt.common.GroupPaginationRequest;
-import org.wso2.carbon.device.mgt.common.PaginationResult;
-import org.wso2.carbon.device.mgt.common.group.mgt.DeviceGroup;
-import org.wso2.carbon.device.mgt.common.group.mgt.GroupManagementException;
 import org.wso2.carbon.device.mgt.core.geo.GeoCluster;
 import org.wso2.carbon.device.mgt.core.geo.geoHash.GeoCoordinate;
-import org.wso2.carbon.device.mgt.core.geo.service.GeoLocationProviderServiceImpl;
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
-import org.wso2.carbon.device.mgt.core.service.GroupManagementProviderService;
 import org.wso2.carbon.device.mgt.jaxrs.service.api.GeoLocationBasedService;
-import org.wso2.carbon.device.mgt.jaxrs.service.api.GroupManagementService;
-import org.wso2.carbon.device.mgt.jaxrs.util.DeviceMgtAPIUtils;
 
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
@@ -33,7 +23,6 @@ public class GeoLocationBasedServiceImplTest {
 
     @BeforeClass
     public void init() {
-        //groupManagementService = new GroupManagementServiceImpl();
         deviceManagementProviderService = Mockito.mock(DeviceManagementProviderService.class);
         geoLocationBasedService = new GeoLocationBasedServiceImpl();
         context = Mockito.mock(PrivilegedCarbonContext.class);
@@ -45,8 +34,8 @@ public class GeoLocationBasedServiceImplTest {
     public void testGetGeoDeviceLocations1() throws DeviceManagementException {
         Mockito.doReturn(new ArrayList<GeoCluster>()).when(deviceManagementProviderService)
                 .findGeoClusters(Mockito.any(GeoCoordinate.class), Mockito.any(GeoCoordinate.class), Mockito.anyInt());
-        Response response = geoLocationBasedService.getGeoDeviceLocations(0.4,15,75.6,
-                90.1,6);
+        Response response = geoLocationBasedService.getGeoDeviceLocations(0.4, 15, 75.6,
+                90.1, 6);
         Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
                 "getGeoDeviceLocations request failed with valid parameters");
     }
@@ -55,16 +44,16 @@ public class GeoLocationBasedServiceImplTest {
             "in the given map boundaries")
     public void testGetGeoDeviceLocations2() throws DeviceManagementException {
         List<GeoCluster> geoClusters = new ArrayList<>();
-        geoClusters.add(new GeoCluster(new GeoCoordinate(1.5,80.7),
-                new GeoCoordinate(1.1,79.5),new GeoCoordinate(1.9,82.1),3,
-                "tb32","aegtew234","android"));
-        geoClusters.add(new GeoCluster(new GeoCoordinate(10.2,86.1),
-                new GeoCoordinate(9.8,84.7),new GeoCoordinate(11.1,88.1),4,
-                "t1gd","swerty12s","android"));
+        geoClusters.add(new GeoCluster(new GeoCoordinate(1.5, 80.7),
+                new GeoCoordinate(1.1, 79.5), new GeoCoordinate(1.9, 82.1), 3,
+                "tb32", "aegtew234", "android"));
+        geoClusters.add(new GeoCluster(new GeoCoordinate(10.2, 86.1),
+                new GeoCoordinate(9.8, 84.7), new GeoCoordinate(11.1, 88.1), 4,
+                "t1gd", "swerty12s", "android"));
         Mockito.doReturn(geoClusters).when(deviceManagementProviderService)
                 .findGeoClusters(Mockito.any(GeoCoordinate.class), Mockito.any(GeoCoordinate.class), Mockito.anyInt());
-        Response response = geoLocationBasedService.getGeoDeviceLocations(0.4,15,75.6,
-                90.1,6);
+        Response response = geoLocationBasedService.getGeoDeviceLocations(0.4, 15, 75.6,
+                90.1, 6);
         Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
                 "getGeoDeviceLocations request failed with valid parameters");
     }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/GeoLocationBasedServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/GeoLocationBasedServiceImplTest.java
@@ -1,0 +1,71 @@
+package org.wso2.carbon.device.mgt.jaxrs.service.impl;
+
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.device.mgt.common.DeviceManagementException;
+import org.wso2.carbon.device.mgt.common.GroupPaginationRequest;
+import org.wso2.carbon.device.mgt.common.PaginationResult;
+import org.wso2.carbon.device.mgt.common.group.mgt.DeviceGroup;
+import org.wso2.carbon.device.mgt.common.group.mgt.GroupManagementException;
+import org.wso2.carbon.device.mgt.core.geo.GeoCluster;
+import org.wso2.carbon.device.mgt.core.geo.geoHash.GeoCoordinate;
+import org.wso2.carbon.device.mgt.core.geo.service.GeoLocationProviderServiceImpl;
+import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
+import org.wso2.carbon.device.mgt.core.service.GroupManagementProviderService;
+import org.wso2.carbon.device.mgt.jaxrs.service.api.GeoLocationBasedService;
+import org.wso2.carbon.device.mgt.jaxrs.service.api.GroupManagementService;
+import org.wso2.carbon.device.mgt.jaxrs.util.DeviceMgtAPIUtils;
+
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+
+public class GeoLocationBasedServiceImplTest {
+    private DeviceManagementProviderService deviceManagementProviderService;
+    private PrivilegedCarbonContext context;
+    private GeoLocationBasedService geoLocationBasedService;
+
+    @BeforeClass
+    public void init() {
+        //groupManagementService = new GroupManagementServiceImpl();
+        deviceManagementProviderService = Mockito.mock(DeviceManagementProviderService.class);
+        geoLocationBasedService = new GeoLocationBasedServiceImpl();
+        context = Mockito.mock(PrivilegedCarbonContext.class);
+        Mockito.doReturn("admin").when(context).getUsername();
+    }
+
+    @Test(description = "This method tests the behaviour of getGeoDeviceLocations when there are no devices" +
+            "in the given map boundaries")
+    public void testGetGeoDeviceLocations1() throws DeviceManagementException {
+        Mockito.doReturn(new ArrayList<GeoCluster>()).when(deviceManagementProviderService)
+                .findGeoClusters(Mockito.any(GeoCoordinate.class), Mockito.any(GeoCoordinate.class), Mockito.anyInt());
+        Response response = geoLocationBasedService.getGeoDeviceLocations(0.4,15,75.6,
+                90.1,6);
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
+                "getGeoDeviceLocations request failed with valid parameters");
+    }
+
+    @Test(description = "This method tests the behaviour of getGeoDeviceLocations when there are devices" +
+            "in the given map boundaries")
+    public void testGetGeoDeviceLocations2() throws DeviceManagementException {
+        List<GeoCluster> geoClusters = new ArrayList<>();
+        geoClusters.add(new GeoCluster(new GeoCoordinate(1.5,80.7),
+                new GeoCoordinate(1.1,79.5),new GeoCoordinate(1.9,82.1),3,
+                "tb32","aegtew234","android"));
+        geoClusters.add(new GeoCluster(new GeoCoordinate(10.2,86.1),
+                new GeoCoordinate(9.8,84.7),new GeoCoordinate(11.1,88.1),4,
+                "t1gd","swerty12s","android"));
+        Mockito.doReturn(geoClusters).when(deviceManagementProviderService)
+                .findGeoClusters(Mockito.any(GeoCoordinate.class), Mockito.any(GeoCoordinate.class), Mockito.anyInt());
+        Response response = geoLocationBasedService.getGeoDeviceLocations(0.4,15,75.6,
+                90.1,6);
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
+                "getGeoDeviceLocations request failed with valid parameters");
+    }
+}


### PR DESCRIPTION
## Purpose
Units tests for getGeoDeviceLocations API which will be used to cluster the devices based on their locations and show them in a map. 