### PR TITLE
Fixing https://github.com/wso2/product-iots/issues/1526

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/RoleManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/RoleManagementServiceImpl.java
@@ -604,28 +604,20 @@ public class RoleManagementServiceImpl implements RoleManagementService {
     private List<String> getRolesFromUserStore(String filter, String userStore) throws UserStoreException {
         AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) DeviceMgtAPIUtils.getUserStoreManager();
         String[] roles;
-        boolean filterRolesByName = (!((filter == null) || filter.isEmpty()));
+        if ((filter == null) || filter.isEmpty()) {
+            filter = "*";
+        }
         if (log.isDebugEnabled()) {
             log.debug("Getting the list of user roles");
         }
         if (userStore.equals("all")) {
-            roles = userStoreManager.getRoleNames("*", -1, false, true, true);
+            roles = userStoreManager.getRoleNames(filter, -1, true, true, true);
         } else {
-            roles = userStoreManager.getRoleNames(userStore + "/*", -1, false, true, true);
+            roles = userStoreManager.getRoleNames(userStore + "/" + filter, -1, true, true, true);
         }
-        // removing all internal roles, roles created for Service-providers and application related roles.
         List<String> filteredRoles = new ArrayList<>();
         for (String role : roles) {
-            if (!(role.startsWith("Internal/") || role.startsWith("Authentication/") || role.startsWith(
-                    "Application/"))) {
-                if (!filterRolesByName) {
-                    filteredRoles.add(role);
-                } else {
-                    if (role.contains(filter)) {
-                        filteredRoles.add(role);
-                    }
-                }
-            }
+            filteredRoles.add(role);
         }
         return filteredRoles;
     }


### PR DESCRIPTION
## Purpose
Fixed the below issue: The role listing must retrieve the no of roles which applies to the given filters from the user store, but at the moment we retrieve the 1st set of roles which has roles equivalent to the value of the MaxRoleNameListLength property and then apply the filtering on device management API level. this results in always get the same set of roles and there will be a set of roles which never gets listed in device management API or UI.

Fixed wso2/product-iots#1526
