### PR TITLE
Fixing devicemgt roles not created for newly created tenants

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementConstants.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementConstants.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.device.mgt.core;
 
 import org.wso2.carbon.device.mgt.core.operation.mgt.OperationMgtConstants;
 import org.wso2.carbon.device.mgt.core.operation.mgt.PolicyOperation;
+import org.wso2.carbon.user.api.Permission;
 
 public final class DeviceManagementConstants {
 
@@ -99,4 +100,29 @@ public final class DeviceManagementConstants {
         public static final int DEFAULT_BATCH_SIZE = 1000;
     }
 
+    public static final class User {
+        private User() {
+            throw new AssertionError();
+        }
+
+        public static final String DEFAULT_DEVICE_USER = "Internal/devicemgt-user";
+        public static final String DEFAULT_DEVICE_ADMIN = "Internal/devicemgt-admin";
+
+        // Permissions that are given for a normal device user.
+        public static final Permission[] PERMISSIONS_FOR_DEVICE_USER = {
+                new Permission("/permission/admin/Login", "ui.execute"),
+                new Permission("/permission/admin/device-mgt/device/api/subscribe", "ui.execute"),
+                new Permission("/permission/admin/device-mgt/devices/enroll", "ui.execute"),
+                new Permission("/permission/admin/device-mgt/devices/disenroll", "ui.execute"),
+                new Permission("/permission/admin/device-mgt/devices/owning-device/view", "ui.execute"),
+                new Permission("/permission/admin/manage/portal", "ui.execute")
+        };
+
+        // Permissions that are given for a normal device admin.
+        public static final Permission[] PERMISSIONS_FOR_DEVICE_ADMIN = {
+                new Permission("/permission/admin/device-mgt", "ui.execute"),
+                new Permission("/permission/admin/manage/api", "ui.execute"),
+                new Permission("/permission/admin/manage/portal", "ui.execute")
+        };
+    }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/DeviceManagementServiceComponent.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/DeviceManagementServiceComponent.java
@@ -64,6 +64,7 @@ import org.wso2.carbon.email.sender.core.service.EmailSenderService;
 import org.wso2.carbon.ndatasource.core.DataSourceService;
 import org.wso2.carbon.registry.core.service.RegistryService;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.utils.Axis2ConfigurationContextObserver;
 import org.wso2.carbon.utils.ConfigurationContextService;
 
 import java.util.ArrayList;
@@ -246,8 +247,12 @@ public class DeviceManagementServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("Registering OSGi service DeviceManagementProviderServiceImpl");
         }
-        /* Registering Device Management Service */
+        /* Registering Tenants Observer */
         BundleContext bundleContext = componentContext.getBundleContext();
+        TenantCreateObserver listener = new TenantCreateObserver();
+        bundleContext.registerService(Axis2ConfigurationContextObserver.class.getName(), listener, null);
+
+        /* Registering Device Management Service */
         DeviceManagementProviderService deviceManagementProvider = new DeviceManagementProviderServiceImpl();
         DeviceManagementDataHolder.getInstance().setDeviceManagementProvider(deviceManagementProvider);
         bundleContext.registerService(DeviceManagementProviderService.class.getName(), deviceManagementProvider, null);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/TenantCreateObserver.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/TenantCreateObserver.java
@@ -61,7 +61,7 @@ public class TenantCreateObserver extends AbstractAxis2ConfigurationContextObser
                 );
             }
         } catch (UserStoreException e) {
-            log.error("App manager configuration service is set to publisher bundle.");
+            log.error("Error occurred while creating roles for the tenant: " + tenantDomain + ".");
         }
     }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/TenantCreateObserver.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/TenantCreateObserver.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.device.mgt.core.internal;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.device.mgt.core.DeviceManagementConstants.User;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.utils.AbstractAxis2ConfigurationContextObserver;
+
+/**
+ * Load configuration files to tenant's registry.
+ */
+public class TenantCreateObserver extends AbstractAxis2ConfigurationContextObserver {
+    private static final Log log = LogFactory.getLog(TenantCreateObserver.class);
+
+    /**
+     * Create configuration context.
+     *
+     * @param configurationContext {@link ConfigurationContext} object
+     */
+    public void createdConfigurationContext(ConfigurationContext configurationContext) {
+        String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+
+        try {
+            //Add the devicemgt-user and devicemgt-admin roles if not exists.
+            UserRealm userRealm = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserRealm();
+            UserStoreManager userStoreManager =
+                    DeviceManagementDataHolder.getInstance().getRealmService().getTenantUserRealm(tenantId)
+                            .getUserStoreManager();
+            String tenantAdminName = userRealm.getRealmConfiguration().getAdminUserName();
+            userStoreManager.addRole(User.DEFAULT_DEVICE_USER, null, User.PERMISSIONS_FOR_DEVICE_USER);
+            userStoreManager.addRole(User.DEFAULT_DEVICE_ADMIN, new String[]{tenantAdminName},
+                                     User.PERMISSIONS_FOR_DEVICE_ADMIN);
+            if (log.isDebugEnabled()) {
+                log.debug("Device management roles: " + User.DEFAULT_DEVICE_USER + ", " + User.DEFAULT_DEVICE_ADMIN +
+                                  " created for the tenant:" + tenantDomain + "."
+                );
+                log.debug("Tenant administrator: " + tenantAdminName + "@" + tenantDomain +
+                                  " is assigned to the role:" + User.DEFAULT_DEVICE_ADMIN + "."
+                );
+            }
+        } catch (UserStoreException e) {
+            log.error("App manager configuration service is set to publisher bundle.");
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
> This PR fixes the issue of "devicemgt-admin" and "devicemgt-user" roles not getting created automatically when creating new tenants.

## Issue
> https://github.com/wso2/product-iots/issues/1544