### PR TITLE
Checking if the user store manager class is a sub class of the default

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/util/DeviceMgtAPIUtils.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/util/DeviceMgtAPIUtils.java
@@ -222,14 +222,13 @@ public class DeviceMgtAPIUtils {
 
 
     public static UserStoreCountRetriever getUserStoreCountRetrieverService()
-            throws UserStoreCounterException {
+            throws UserStoreCounterException, UserStoreException {
         PrivilegedCarbonContext ctx = PrivilegedCarbonContext.getThreadLocalCarbonContext();
         List<Object> countRetrieverFactories = ctx.getOSGiServices(AbstractCountRetrieverFactory.class, null);
         RealmService realmService = (RealmService) ctx.getOSGiService(RealmService.class, null);
         RealmConfiguration realmConfiguration = realmService.getBootstrapRealmConfiguration();
         String userStoreType;
-        //Ignoring Sonar warning as getUserStoreClass() returning string name of the class. So cannot use 'instanceof'.
-        if (JDBCUserStoreManager.class.getName().equals(realmConfiguration.getUserStoreClass())) {
+        if(DeviceMgtAPIUtils.getUserStoreManager() instanceof JDBCUserStoreManager) {
             userStoreType = JDBCCountRetrieverFactory.JDBC;
         } else {
             userStoreType = InternalCountRetrieverFactory.INTERNAL;


### PR DESCRIPTION
## Purpose
> Resolves wso2/product-iots#1556

## Goals
> This commit is to modify the current logic which checks if the UserStoreManager class is equal to the JDBCUserStoreManager class to support subclasses of the JDBCUserStoreManager class to return correct total user count.

## Approach
> In this commit, instead of comparing the string name, tests the UserStoreManager instance is a type of JDBCUserStoreManager.