### PR TITLE
Fixing https://github.com/wso2/product-iots/issues/1565

### DIFF
--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -39,13 +39,13 @@
     <PolicyConfiguration>
         <monitoringClass>org.wso2.carbon.policy.mgt</monitoringClass>
         <monitoringEnable>true</monitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <monitoringFrequency>60000</monitoringFrequency>
         <maxRetries>5</maxRetries>
         <minRetriesToMarkUnreachable>8</minRetriesToMarkUnreachable>
         <minRetriesToMarkInactive>20</minRetriesToMarkInactive>
         <!--<PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>-->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!--This specifies whether to enable the DeviceStatus Task in this node.-->
     <DeviceStatusTaskConfig>

--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -39,6 +39,7 @@
     <PolicyConfiguration>
         <monitoringClass>org.wso2.carbon.policy.mgt</monitoringClass>
         <monitoringEnable>true</monitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <monitoringFrequency>60000</monitoringFrequency>
         <maxRetries>5</maxRetries>
         <minRetriesToMarkUnreachable>8</minRetriesToMarkUnreachable>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/config/policy/PolicyConfiguration.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/config/policy/PolicyConfiguration.java
@@ -34,6 +34,7 @@ public class PolicyConfiguration {
     private int minRetriesToMarkInactive;
     private List<String> platforms;
     private String policyEvaluationPoint;
+    private boolean cacheEnable;
 
     @XmlElement(name = "MonitoringClass", required = true)
     public String getMonitoringClass() {
@@ -106,6 +107,15 @@ public class PolicyConfiguration {
 
     public void setPolicyEvaluationPointName(String policyEvaluationPointName) {
         this.policyEvaluationPoint = policyEvaluationPointName;
+    }
+
+    @XmlElement(name = "CacheEnable", required = true)
+    public boolean getCacheEnable() {
+        return cacheEnable;
+    }
+
+    public void setCacheEnable(boolean cacheEnable) {
+        this.cacheEnable = cacheEnable;
     }
 
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -49,7 +49,6 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>
@@ -58,6 +57,7 @@
         <!--Simple ->  Simple policy evaluation point-->
         <!--Merged ->  Merged policy evaluation point -->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!-- Default Page size configuration for paginated DM APIs-->
     <PaginationConfiguration>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -49,6 +49,7 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/config/operation/cdm-config.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/config/operation/cdm-config.xml
@@ -49,7 +49,6 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>
@@ -58,6 +57,7 @@
         <!--Simple ->  Simple policy evaluation point-->
         <!--Merged ->  Merged policy evaluation point -->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!-- Default Page size configuration for paginated DM APIs-->
     <PaginationConfiguration>

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/config/operation/cdm-config.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/resources/config/operation/cdm-config.xml
@@ -49,6 +49,7 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>

--- a/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -54,6 +54,7 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>

--- a/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -54,7 +54,6 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>
@@ -63,6 +62,7 @@
         <!--Simple ->  Simple policy evaluation point-->
         <!--Merged ->  Merged policy evaluation point -->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!-- Default Page size configuration for paginated DM APIs-->
     <PaginationConfiguration>

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/enforcement/DelegationTask.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/enforcement/DelegationTask.java
@@ -23,6 +23,8 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.device.mgt.common.Device;
 import org.wso2.carbon.device.mgt.common.DeviceManagementException;
 import org.wso2.carbon.device.mgt.common.EnrolmentInfo;
+import org.wso2.carbon.device.mgt.core.config.DeviceConfigurationManager;
+import org.wso2.carbon.device.mgt.core.config.policy.PolicyConfiguration;
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.ntask.core.Task;
 import org.wso2.carbon.policy.mgt.common.PolicyManagementException;
@@ -39,6 +41,7 @@ import java.util.Map;
 public class DelegationTask implements Task {
 
     private static final Log log = LogFactory.getLog(DelegationTask.class);
+    private PolicyConfiguration policyConfiguration = DeviceConfigurationManager.getInstance().getDeviceManagementConfig().getPolicyConfiguration();
 
     @Override
     public void setProperties(Map<String, String> map) {
@@ -57,9 +60,9 @@ public class DelegationTask implements Task {
             PolicyManager policyManager = new PolicyManagerImpl();
             UpdatedPolicyDeviceListBean updatedPolicyDeviceList = policyManager.applyChangesMadeToPolicies();
             List<String> deviceTypes = updatedPolicyDeviceList.getChangedDeviceTypes();
-
-            PolicyCacheManagerImpl.getInstance().rePopulateCache();
-
+            if (policyConfiguration.getCacheEnable()) {
+                PolicyCacheManagerImpl.getInstance().rePopulateCache();
+            }
             if (log.isDebugEnabled()) {
                 log.debug("Number of device types which policies are changed .......... : " + deviceTypes.size());
             }

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/impl/PolicyAdministratorPointImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/impl/PolicyAdministratorPointImpl.java
@@ -24,6 +24,8 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.device.mgt.common.DeviceIdentifier;
 import org.wso2.carbon.device.mgt.common.policy.mgt.Policy;
 import org.wso2.carbon.device.mgt.common.policy.mgt.Profile;
+import org.wso2.carbon.device.mgt.core.config.DeviceConfigurationManager;
+import org.wso2.carbon.device.mgt.core.config.policy.PolicyConfiguration;
 import org.wso2.carbon.ntask.common.TaskException;
 import org.wso2.carbon.ntask.core.TaskInfo;
 import org.wso2.carbon.ntask.core.TaskManager;
@@ -53,6 +55,7 @@ public class PolicyAdministratorPointImpl implements PolicyAdministratorPoint {
     private ProfileManager profileManager;
     private FeatureManager featureManager;
     private PolicyCacheManager cacheManager;
+    private PolicyConfiguration policyConfiguration;
     // private PolicyEnforcementDelegator delegator;
 
     public PolicyAdministratorPointImpl() {
@@ -60,6 +63,7 @@ public class PolicyAdministratorPointImpl implements PolicyAdministratorPoint {
         this.profileManager = new ProfileManagerImpl();
         this.featureManager = new FeatureManagerImpl();
         this.cacheManager = PolicyCacheManagerImpl.getInstance();
+        this.policyConfiguration = DeviceConfigurationManager.getInstance().getDeviceManagementConfig().getPolicyConfiguration();
         // this.delegator = new PolicyEnforcementDelegatorImpl();
     }
 
@@ -71,7 +75,9 @@ public class PolicyAdministratorPointImpl implements PolicyAdministratorPoint {
 //        } catch (PolicyDelegationException e) {
 //            throw new PolicyManagementException("Error occurred while delegating policy operation to the devices", e);
 //        }
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
         return resultantPolicy;
     }
 
@@ -83,42 +89,54 @@ public class PolicyAdministratorPointImpl implements PolicyAdministratorPoint {
 //        } catch (PolicyDelegationException e) {
 //            throw new PolicyManagementException("Error occurred while delegating policy operation to the devices", e);
 //        }
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
         return resultantPolicy;
     }
 
     @Override
     public boolean updatePolicyPriorities(List<Policy> policies) throws PolicyManagementException {
         boolean bool = policyManager.updatePolicyPriorities(policies);
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
         return bool;
     }
 
     @Override
     public void activatePolicy(int policyId) throws PolicyManagementException {
         policyManager.activatePolicy(policyId);
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
     }
 
     @Override
     public void inactivatePolicy(int policyId) throws PolicyManagementException {
         policyManager.inactivatePolicy(policyId);
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
     }
 
     @Override
     public boolean deletePolicy(Policy policy) throws PolicyManagementException {
         boolean bool = policyManager.deletePolicy(policy);
-        PolicyCacheManager policyCacheManager = PolicyCacheManagerImpl.getInstance();
-        policyCacheManager.rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManager policyCacheManager = PolicyCacheManagerImpl.getInstance();
+            policyCacheManager.rePopulateCache();
+        }
         return bool;
     }
 
     @Override
     public boolean deletePolicy(int policyId) throws PolicyManagementException {
         boolean bool = policyManager.deletePolicy(policyId);
-        PolicyCacheManager policyCacheManager = PolicyCacheManagerImpl.getInstance();
-        policyCacheManager.rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManager policyCacheManager = PolicyCacheManagerImpl.getInstance();
+            policyCacheManager.rePopulateCache();
+        }
         return bool;
     }
 
@@ -222,25 +240,37 @@ public class PolicyAdministratorPointImpl implements PolicyAdministratorPoint {
     public Policy addPolicyToDevice(List<DeviceIdentifier> deviceIdentifierList, Policy policy) throws
             PolicyManagementException {
         policy = policyManager.addPolicyToDevice(deviceIdentifierList, policy);
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
         return policy;
     }
 
     @Override
     public Policy addPolicyToRole(List<String> roleNames, Policy policy) throws PolicyManagementException {
         policy = policyManager.addPolicyToRole(roleNames, policy);
-        PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        if (policyConfiguration.getCacheEnable()) {
+            PolicyCacheManagerImpl.getInstance().rePopulateCache();
+        }
         return policy;
     }
 
     @Override
     public List<Policy> getPolicies() throws PolicyManagementException {
-        return PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        if (policyConfiguration.getCacheEnable()) {
+            return PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        } else {
+            return policyManager.getPolicies();
+        }
     }
 
     @Override
     public Policy getPolicy(int policyId) throws PolicyManagementException {
-        return PolicyCacheManagerImpl.getInstance().getPolicy(policyId);
+        if (policyConfiguration.getCacheEnable()) {
+            return PolicyCacheManagerImpl.getInstance().getPolicy(policyId);
+        } else {
+            return policyManager.getPolicy(policyId);
+        }
     }
 
     @Override
@@ -340,7 +370,11 @@ public class PolicyAdministratorPointImpl implements PolicyAdministratorPoint {
 
     @Override
     public int getPolicyCount() throws PolicyManagementException {
-        return PolicyCacheManagerImpl.getInstance().getAllPolicies().size();
+        if (policyConfiguration.getCacheEnable()) {
+            return PolicyCacheManagerImpl.getInstance().getAllPolicies().size();
+        } else {
+            return policyManager.getPolicyCount();
+        }
     }
 
 }

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/mgt/impl/PolicyManagerImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/mgt/impl/PolicyManagerImpl.java
@@ -44,9 +44,6 @@ import org.wso2.carbon.device.mgt.core.service.GroupManagementProviderServiceImp
 import org.wso2.carbon.policy.mgt.common.*;
 import org.wso2.carbon.policy.mgt.core.cache.impl.PolicyCacheManagerImpl;
 import org.wso2.carbon.policy.mgt.core.dao.*;
-import org.wso2.carbon.policy.mgt.core.enforcement.PolicyDelegationException;
-import org.wso2.carbon.policy.mgt.core.enforcement.PolicyEnforcementDelegator;
-import org.wso2.carbon.policy.mgt.core.enforcement.PolicyEnforcementDelegatorImpl;
 import org.wso2.carbon.policy.mgt.core.internal.PolicyManagementDataHolder;
 import org.wso2.carbon.policy.mgt.core.mgt.PolicyManager;
 import org.wso2.carbon.policy.mgt.core.mgt.ProfileManager;
@@ -60,7 +57,6 @@ import java.util.*;
 public class PolicyManagerImpl implements PolicyManager {
 
     private PolicyDAO policyDAO;
-    private PolicyManager policyManager;
     private ProfileDAO profileDAO;
     private FeatureDAO featureDAO;
     private ProfileManager profileManager;
@@ -73,7 +69,6 @@ public class PolicyManagerImpl implements PolicyManager {
         this.featureDAO = PolicyManagementDAOFactory.getFeatureDAO();
         this.policyConfiguration = DeviceConfigurationManager.getInstance().getDeviceManagementConfig().getPolicyConfiguration();
         this.profileManager = new ProfileManagerImpl();
-        this.policyManager = new PolicyManagerImpl();
     }
 
     @Override
@@ -282,7 +277,7 @@ public class PolicyManagerImpl implements PolicyManager {
             if (policyConfiguration.getCacheEnable()) {
                 existingPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
             } else {
-                existingPolicies = policyManager.getPolicies();
+                existingPolicies = this.getPolicies();
             }
             PolicyManagementDAOFactory.beginTransaction();
             bool = policyDAO.updatePolicyPriorities(policies);
@@ -698,7 +693,7 @@ public class PolicyManagerImpl implements PolicyManager {
         if (policyConfiguration.getCacheEnable()) {
             tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
         } else {
-            tempPolicyList = policyManager.getPolicies();
+            tempPolicyList = this.getPolicies();
         }
 
         for (Policy policy : tempPolicyList) {
@@ -723,7 +718,7 @@ public class PolicyManagerImpl implements PolicyManager {
         if (policyConfiguration.getCacheEnable()) {
             allPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
         } else {
-            allPolicies = policyManager.getPolicies();
+            allPolicies = this.getPolicies();
         }
 
         for (Policy policy : allPolicies) {
@@ -770,7 +765,7 @@ public class PolicyManagerImpl implements PolicyManager {
         if (policyConfiguration.getCacheEnable()) {
             tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
         } else {
-            tempPolicyList = policyManager.getPolicies();
+            tempPolicyList = this.getPolicies();
         }
 
         for (Policy policy : tempPolicyList) {
@@ -805,7 +800,7 @@ public class PolicyManagerImpl implements PolicyManager {
         if (policyConfiguration.getCacheEnable()) {
             tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
         } else {
-            tempPolicyList = policyManager.getPolicies();
+            tempPolicyList = this.getPolicies();
         }
 
         for (Policy policy : tempPolicyList) {

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/mgt/impl/PolicyManagerImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/mgt/impl/PolicyManagerImpl.java
@@ -898,7 +898,7 @@ public class PolicyManagerImpl implements PolicyManager {
             if (policyConfiguration.getCacheEnable()) {
                 allPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
             } else {
-                allPolicies = policyDAO.getAllPolicies();
+                allPolicies = this.getPolicies();
             }
             for (Policy policy : allPolicies) {
                 if (policy.isUpdated()) {

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/mgt/impl/PolicyManagerImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/mgt/impl/PolicyManagerImpl.java
@@ -33,6 +33,8 @@ import org.wso2.carbon.device.mgt.common.policy.mgt.Policy;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyCriterion;
 import org.wso2.carbon.device.mgt.common.policy.mgt.Profile;
 import org.wso2.carbon.device.mgt.common.policy.mgt.ProfileFeature;
+import org.wso2.carbon.device.mgt.core.config.DeviceConfigurationManager;
+import org.wso2.carbon.device.mgt.core.config.policy.PolicyConfiguration;
 import org.wso2.carbon.device.mgt.core.operation.mgt.CommandOperation;
 import org.wso2.carbon.device.mgt.core.operation.mgt.OperationMgtConstants;
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
@@ -58,16 +60,20 @@ import java.util.*;
 public class PolicyManagerImpl implements PolicyManager {
 
     private PolicyDAO policyDAO;
+    private PolicyManager policyManager;
     private ProfileDAO profileDAO;
     private FeatureDAO featureDAO;
     private ProfileManager profileManager;
+    private PolicyConfiguration policyConfiguration;
     private static Log log = LogFactory.getLog(PolicyManagerImpl.class);
 
     public PolicyManagerImpl() {
         this.policyDAO = PolicyManagementDAOFactory.getPolicyDAO();
         this.profileDAO = PolicyManagementDAOFactory.getProfileDAO();
         this.featureDAO = PolicyManagementDAOFactory.getFeatureDAO();
+        this.policyConfiguration = DeviceConfigurationManager.getInstance().getDeviceManagementConfig().getPolicyConfiguration();
         this.profileManager = new ProfileManagerImpl();
+        this.policyManager = new PolicyManagerImpl();
     }
 
     @Override
@@ -272,7 +278,12 @@ public class PolicyManagerImpl implements PolicyManager {
         boolean bool;
         try {
 //            List<Policy> existingPolicies = this.getPolicies();
-            List<Policy> existingPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+            List<Policy> existingPolicies; 
+            if (policyConfiguration.getCacheEnable()) {
+                existingPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+            } else {
+                existingPolicies = policyManager.getPolicies();
+            }
             PolicyManagementDAOFactory.beginTransaction();
             bool = policyDAO.updatePolicyPriorities(policies);
 
@@ -683,7 +694,12 @@ public class PolicyManagerImpl implements PolicyManager {
         }
 
 //        List<Policy> tempPolicyList = this.getPolicies();
-        List<Policy> tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        List<Policy> tempPolicyList;
+        if (policyConfiguration.getCacheEnable()) {
+            tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        } else {
+            tempPolicyList = policyManager.getPolicies();
+        }
 
         for (Policy policy : tempPolicyList) {
             for (Integer i : policyIdList) {
@@ -703,7 +719,12 @@ public class PolicyManagerImpl implements PolicyManager {
 //        try {
         // List<Profile> profileList = profileManager.getProfilesOfDeviceType(deviceTypeName);
 //            List<Policy> allPolicies = this.getPolicies();
-        List<Policy> allPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        List<Policy> allPolicies;
+        if (policyConfiguration.getCacheEnable()) {
+            allPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        } else {
+            allPolicies = policyManager.getPolicies();
+        }
 
         for (Policy policy : allPolicies) {
             if (policy.getProfile().getDeviceType().equalsIgnoreCase(deviceTypeName)) {
@@ -745,7 +766,12 @@ public class PolicyManagerImpl implements PolicyManager {
         }
 
 //        List<Policy> tempPolicyList = this.getPolicies();
-        List<Policy> tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        List<Policy> tempPolicyList;
+        if (policyConfiguration.getCacheEnable()) {
+            tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        } else {
+            tempPolicyList = policyManager.getPolicies();
+        }
 
         for (Policy policy : tempPolicyList) {
             for (Integer i : policyIdList) {
@@ -775,7 +801,12 @@ public class PolicyManagerImpl implements PolicyManager {
             PolicyManagementDAOFactory.closeConnection();
         }
 //        List<Policy> tempPolicyList = this.getPolicies();
-        List<Policy> tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        List<Policy> tempPolicyList;
+        if (policyConfiguration.getCacheEnable()) {
+            tempPolicyList = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+        } else {
+            tempPolicyList = policyManager.getPolicies();
+        }
 
         for (Policy policy : tempPolicyList) {
             for (Integer i : policyIdList) {
@@ -868,8 +899,12 @@ public class PolicyManagerImpl implements PolicyManager {
 //            List<Policy> inactivePolicies = new ArrayList<>();
 
 //            List<Policy> allPolicies = this.getPolicies();
-            List<Policy> allPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
-
+            List<Policy> allPolicies;
+            if (policyConfiguration.getCacheEnable()) {
+                allPolicies = PolicyCacheManagerImpl.getInstance().getAllPolicies();
+            } else {
+                allPolicies = policyDAO.getAllPolicies();
+            }
             for (Policy policy : allPolicies) {
                 if (policy.isUpdated()) {
                     updatedPolicies.add(policy);

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -39,13 +39,13 @@
     <PolicyConfiguration>
         <monitoringClass>org.wso2.carbon.policy.mgt</monitoringClass>
         <monitoringEnable>true</monitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <monitoringFrequency>60000</monitoringFrequency>
         <maxRetries>5</maxRetries>
         <minRetriesToMarkUnreachable>8</minRetriesToMarkUnreachable>
         <minRetriesToMarkInactive>20</minRetriesToMarkInactive>
         <!--<PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>-->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!--This specifies whether to enable the DeviceStatus Task in this node.-->
     <DeviceStatusTaskConfig>

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -39,6 +39,7 @@
     <PolicyConfiguration>
         <monitoringClass>org.wso2.carbon.policy.mgt</monitoringClass>
         <monitoringEnable>true</monitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <monitoringFrequency>60000</monitoringFrequency>
         <maxRetries>5</maxRetries>
         <minRetriesToMarkUnreachable>8</minRetriesToMarkUnreachable>

--- a/components/webapp-authenticator-framework/org.wso2.carbon.webapp.authenticator.framework/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/webapp-authenticator-framework/org.wso2.carbon.webapp.authenticator.framework/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -49,7 +49,6 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>
@@ -58,6 +57,7 @@
         <!--Simple ->  Simple policy evaluation point-->
         <!--Merged ->  Merged policy evaluation point -->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!-- Default Page size configuration for paginated DM APIs-->
     <PaginationConfiguration>

--- a/components/webapp-authenticator-framework/org.wso2.carbon.webapp.authenticator.framework/src/test/resources/carbon-home/repository/conf/cdm-config.xml
+++ b/components/webapp-authenticator-framework/org.wso2.carbon.webapp.authenticator.framework/src/test/resources/carbon-home/repository/conf/cdm-config.xml
@@ -49,6 +49,7 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>

--- a/features/device-mgt/org.wso2.carbon.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/org.wso2.carbon.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
@@ -54,6 +54,7 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
+        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>

--- a/features/device-mgt/org.wso2.carbon.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/org.wso2.carbon.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
@@ -54,7 +54,6 @@
     <PolicyConfiguration>
         <MonitoringClass>org.wso2.carbon.policy.mgt</MonitoringClass>
         <MonitoringEnable>true</MonitoringEnable>
-        <CacheEnable>true</CacheEnable>
         <MonitoringFrequency>60000</MonitoringFrequency>
         <MaxRetries>5</MaxRetries>
         <MinRetriesToMarkUnreachable>8</MinRetriesToMarkUnreachable>
@@ -63,6 +62,7 @@
         <!--Simple ->  Simple policy evaluation point-->
         <!--Merged ->  Merged policy evaluation point -->
         <PolicyEvaluationPoint>Simple</PolicyEvaluationPoint>
+        <CacheEnable>true</CacheEnable>
     </PolicyConfiguration>
     <!-- Default Page size configuration for paginated DM APIs-->
     <PaginationConfiguration>


### PR DESCRIPTION
## Purpose
> Resolves /wso2/product-iots#1565

## Goals
> Enable configuration to disable the policy cache

## Approach
> Enable the configuration file and related beans to have a cacheEnable property and change the implementation of policy management in order to disable or enable cache according to the configuration.
