### PR TITLE
Fixing https://github.com/wso2/product-iots/issues/1547

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_remote.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_remote.js
@@ -182,12 +182,9 @@ function setSpeedAlert() {
     //TODO: get the device Id from the URL
     var speedAlertValue = $("#speedAlertValue").val();
 
-    if (speedAlertValue == null || speedAlertValue === undefined || speedAlertValue == "") {
+    if (!speedAlertValue) {
         var message = "Speed cannot be empty.";
         noty({text:  message, type : 'error' });
-    } else if (areaName.indexOf(" ") > -1) {
-        var message = "Area Name cannot contain spaces.";
-        noty({text: message, type : 'error' });
     } else {
         data = {
             'parseData': JSON.stringify({'speedAlertValue': speedAlertValue, 'deviceId': deviceId}), // parseKey : parseValue pair , this key pair is replace with the key in the template file


### PR DESCRIPTION
## Purpose
> When setting speed alerts; UI is getting freezed. When checking browser console; a null reference error log visible as described in https://github.com/wso2/product-iots/issues/1547.

## Goals
> Removed unnecessary if checks which is causing a null reference

## Approach
> Removed the unnecessary if check for fenceName.

## User stories
> N/A

## Release note
> Fixing cannot set speed alerts issue

## Documentation
> N/A (fixing a bug)

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Maven home: /usr/local/Cellar/maven/3.5.2/libexec
> Java version: 1.8.0_141, vendor: Oracle Corporation
> Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_141.jdk/Contents/Home/jre
> Default locale: en_US, platform encoding: UTF-8
> OS name: "mac os x", version: "10.13.2", arch: "x86_64", family: "mac"
 
## Learning
> N/A