### PR TITLE
Fixed android-web-agent download URL

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
@@ -9,7 +9,7 @@
   "remoteSessionWSURL": "https://%iot.core.host%:%iot.core.https.port%",
   "portalURL": "https://%iot.analytics.host%:%iot.analytics.https.port%",
   "dashboardServerURL": "%https.ip%",
-  "androidEnrollmentDir": "/android-web-agent/enrollment",
+  "androidAgentDownloadURL": "%https.ip%/devicemgt/public/cdmf.unit.device.type.android.type-view/assets/android-agent.apk",
   "windowsEnrollmentDir": "/windows-web-agent/enrollment",
   "iOSEnrollmentDir": "/ios-web-agent/enrollment",
   "iOSConfigRoot": "%https.ip%/ios-enrollment/",


### PR DESCRIPTION
## Purpose
> Android Web Agent download URL is not customizable since we are prefixing android-web-agent app hostname internally. Resolves https://github.com/wso2/product-iots/issues/1573

## Goals
>  Introduced a new config element for the agent download URL. When configuring the server you can even setup an **external download link**(eg. CDN enabled link) to handle the agent APK download load for the server.

## Approach
> This PR introduces a new config element(aka. "androidAgentDownloadURL") into the `config.json` of the` /devicemgt` app.

## User stories
> N/A

## Release note
> Introduced a new android agent download url and removed android-web-agent app.

## Documentation
> https://docs.wso2.com/display/IOTS320/Customizing+the+Android+APK+File
> https://docs.wso2.com/display/IOTS320/White+Labeling+the+WSO2+Android+Agent
> https://docs.wso2.com/display/IOTS320/Customizing+the+Android+Agent+to+Disable+the+Get+Location+Operation
> https://docs.wso2.com/display/IOTS320/Configuring+the+IP+or+Hostname

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> 1. If you are using default devicemgt app to serve android APK file; open 
the `<IOTS_HOME>/repository/deployment/server/jaggeryapps/devicemgt/app/conf/config.json` file and configure the `androidAgentDownloadURL` property like following samples.
> 
> - Sample 1:
> `"androidAgentDownloadURL": "https://%iot.manager.host%:%iot.manager.https.port%/android-web-agent/public/mdm.page.enrollments.android.download-agent/asset/android-agent.apk",`
> - Sample 2:
> `"androidAgentDownloadURL": "<EXTERNAL_URL>/android-agent.apk",`
> 
> 2. If you need **tenant based** android agent APKs you can simply add a new unit named as `<tenant_domain>.cdmf.unit.device.type.android.type-view`. For example; `wso2.org.cdmf.unit.device.type.android.type-view`.

## Related PRs
> - https://github.com/wso2/carbon-device-mgt-plugins/pull/863
> - https://github.com/wso2/product-iots/pull/1582

## Migrations (if applicable)
> N/A

## Test environment
>Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_141, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_141.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.2", arch: "x86_64", family: "mac"
 
## Learning
> N/A
  