### PR TITLE
Changing the generic application retrieval to get the application ids

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/app/mgt/ApplicationManagerProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/app/mgt/ApplicationManagerProviderServiceImpl.java
@@ -239,7 +239,7 @@ public class ApplicationManagerProviderServiceImpl implements ApplicationManagem
                 }
                 if (!installedAppList.contains(application)) {
                     installedApp = applicationDAO.getApplication(application.getApplicationIdentifier(),
-                            application.getVersion(), device.getId(), tenantId);
+                            application.getVersion(), tenantId);
                     if (installedApp == null) {
                         appsToAdd.add(application);
                     } else {
@@ -255,7 +255,7 @@ public class ApplicationManagerProviderServiceImpl implements ApplicationManagem
             // Getting the applications ids for the second time
             for (Application application : appsToAdd) {
                 installedApp = applicationDAO.getApplication(application.getApplicationIdentifier(),
-                        application.getVersion(), device.getId(), tenantId);
+                        application.getVersion(), tenantId);
                 application.setId(installedApp.getId());
                 applicationsToMap.add(application);
             }


### PR DESCRIPTION
## Purpose
This fixes the issue caused due to retrieving the application details by submitting the device id, because, at the first storing of the application, they are not stored against a device. It get's mapped later with the device. Hence it caused a null pointer

## Goals
Fixing a null pointer 

## Approach
Changing the getApplication Method

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
NA

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
NA
 
## Learning
NA.