### PR TITLE
The device identity certificate's subject name has a hardcoded value

### DIFF
--- a/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/impl/CertificateGenerator.java
+++ b/components/certificate-mgt/org.wso2.carbon.certificate.mgt.core/src/main/java/org/wso2/carbon/certificate/mgt/core/impl/CertificateGenerator.java
@@ -427,7 +427,10 @@ public class CertificateGenerator {
         Date validityBeginDate = commonUtil.getValidityStartDate();
         Date validityEndDate = commonUtil.getValidityEndDate();
 
-        X500Name certSubject = new X500Name(CertificateManagementConstants.DEFAULT_PRINCIPAL);
+        X500Name certSubject = request.getSubject();
+        if (certSubject == null) { //This is highly unlikely as the csr must have a subject name.
+            certSubject = new X500Name(CertificateManagementConstants.DEFAULT_PRINCIPAL);
+        }
         Attribute attributes[] = request.getAttributes();
 
         RDN[] certUniqueIdRDN;


### PR DESCRIPTION
## Purpose
The device identity certificate of iOS contains a harcoded value.
https://github.com/wso2/product-iots/issues/1601

## Goals
To extract the subject name of the CSR when generating the certificates.

## Approach
Instead of using a hard coded value, for subject name, request is used to get the csr's subject name

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A.

## Marketing
N/A

## Automation tests
 Already covered

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
iOS 11, JDK 1.8
 
## Learning
N/A