### PR TITLE
New Activity Info Provider API resource which accept an array of activity IDs to get activity information

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/common/ActivityIdList.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/common/ActivityIdList.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.device.mgt.jaxrs.common;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ActivityIdList {
+
+    private String ids;
+    private List<String> idList;
+
+    public ActivityIdList(String ids) {
+        this.ids = ids;
+        if(ids != null) {
+            String[] splits = ids.split(",");
+            if (splits.length > 1 && splits[0] != null && !splits[0].isEmpty()) {
+                idList = Arrays.asList(splits);
+            }
+        }
+    }
+
+    public List<String> getIdList() {
+        return idList;
+    }
+
+    public String getIds() {
+        return ids;
+    }
+}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/common/ActivityIdList.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/common/ActivityIdList.java
@@ -28,9 +28,9 @@ public class ActivityIdList {
 
     public ActivityIdList(String ids) {
         this.ids = ids;
-        if(ids != null) {
+        if (ids != null) {
             String[] splits = ids.split(",");
-            if (splits.length > 1 && splits[0] != null && !splits[0].isEmpty()) {
+            if (splits.length > 0 && splits[0] != null && !splits[0].isEmpty()) {
                 idList = Arrays.asList(splits);
             }
         }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/common/ActivityIdList.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/common/ActivityIdList.java
@@ -30,7 +30,7 @@ public class ActivityIdList {
         this.ids = ids;
         if (ids != null) {
             String[] splits = ids.split(",");
-            if (splits.length > 0 && splits[0] != null && !splits[0].isEmpty()) {
+            if (splits.length > 0 && splits.length < 11 && splits[0] != null && !splits[0].isEmpty()) {
                 idList = Arrays.asList(splits);
             }
         }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/api/ActivityInfoProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/api/ActivityInfoProviderService.java
@@ -18,16 +18,33 @@
  */
 package org.wso2.carbon.device.mgt.jaxrs.service.api;
 
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Extension;
+import io.swagger.annotations.ExtensionProperty;
+import io.swagger.annotations.Info;
+import io.swagger.annotations.ResponseHeader;
+import io.swagger.annotations.SwaggerDefinition;
+import io.swagger.annotations.Tag;
 import org.wso2.carbon.apimgt.annotations.api.Scope;
 import org.wso2.carbon.apimgt.annotations.api.Scopes;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Activity;
 import org.wso2.carbon.device.mgt.jaxrs.beans.ActivityList;
 import org.wso2.carbon.device.mgt.jaxrs.beans.ErrorResponse;
+import org.wso2.carbon.device.mgt.jaxrs.common.ActivityIdList;
 import org.wso2.carbon.device.mgt.jaxrs.util.Constants;
 
 import javax.validation.constraints.Size;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -138,6 +155,68 @@ public interface ActivityInfoProviderService {
                             "Example: Mon, 05 Jan 2014 15:10:00 +0200",
                     required = false)
             @HeaderParam("If-Modified-Since") String ifModifiedSince);
+
+    @GET
+    @Path("/ids")
+    @ApiOperation(
+            produces = MediaType.APPLICATION_JSON,
+            httpMethod = "GET",
+            value = "Getting Details of activities for given set of activity/operation Ids",
+            notes = "Retrieve the details of specific activity/operation Ids, such as the meta information of " +
+                    "an operation, including the responses from the devices.",
+            tags = "Activity Info Provider",
+            extensions = {
+                    @Extension(properties = {
+                            @ExtensionProperty(name = Constants.SCOPE, value = "perm:get-activity")
+                    })
+            }
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    code = 200,
+                    message = "OK. \n Successfully fetched the activity details.",
+                    response = Activity.class,
+                    responseHeaders = {
+                            @ResponseHeader(
+                                    name = "Content-Type",
+                                    description = "The content type of the body"),
+                            @ResponseHeader(
+                                    name = "ETag",
+                                    description = "Entity Tag of the response resource.\n" +
+                                            "Used by caches, or in conditional requests."),
+                            @ResponseHeader(
+                                    name = "Last-Modified",
+                                    description = "Date and time the resource was last modified.\n" +
+                                            "Used by caches, or in conditional requests."),
+                    }),
+            @ApiResponse(
+                    code = 400,
+                    message = "Bad Request. \n Activity Ids shouldn't be empty",
+                    response = ErrorResponse.class),
+            @ApiResponse(
+                    code = 401,
+                    message = "Unauthorized. \n Unauthorized operation! Only admin role can perform this "
+                            + "operation."),
+            @ApiResponse(
+                    code = 404,
+                    message = "Not Found. \n No activity found with the given IDs.",
+                    response = ErrorResponse.class),
+            @ApiResponse(
+                    code = 406,
+                    message = "Not Acceptable.\n The requested media type is not supported"),
+            @ApiResponse(
+                    code = 500,
+                    message = "Internal Server Error. \n ErrorResponse occurred while fetching the activity "
+                            + "list for the supplied ids.",
+                    response = ErrorResponse.class)
+    })
+    Response getActivities(
+            @ApiParam(
+                    name = "ids",
+                    value = "Comma separated activity/operation ids",
+                    required = true,
+                    defaultValue = "ACTIVITY_0")
+            @QueryParam("ids") ActivityIdList activityIdList);
 
 
     @GET

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/ActivityProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/ActivityProviderServiceImpl.java
@@ -93,24 +93,24 @@ public class ActivityProviderServiceImpl implements ActivityInfoProviderService 
 
         List<String> idList;
         idList = activityIdList.getIdList();
-
         if (idList == null || idList.isEmpty()) {
             String msg = "Activity Ids shouldn't be empty";
             log.error(msg);
             return Response.status(400).entity(
                     new ErrorResponse.ErrorResponseBuilder().setMessage(msg).build()).build();
         }
-
         Response validationFailedResponse = validateAdminUser();
         if (validationFailedResponse == null) {
             List<Activity> activities;
             ActivityList activityList = new ActivityList();
             DeviceManagementProviderService dmService;
             try {
-                idList.forEach(RequestValidationUtil::validateActivityId);
+                for (String id : idList) {
+                    RequestValidationUtil.validateActivityId(id);
+                }
                 dmService = DeviceMgtAPIUtils.getDeviceManagementService();
                 activities = dmService.getOperationByActivityIds(idList);
-                if(!activities.isEmpty()){
+                if (!activities.isEmpty()) {
                     activityList.setList(activities);
                     int count = activities.size();
                     if (log.isDebugEnabled()) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/util/RequestValidationUtil.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/util/RequestValidationUtil.java
@@ -188,24 +188,24 @@ public class RequestValidationUtil {
 
     public static void validateActivityId(String activityId) {
         if (activityId == null || activityId.isEmpty()) {
-            throw new InputValidationException(
-                    new ErrorResponse.ErrorResponseBuilder().setCode(400l).setMessage("Activity Id " +
-                            "cannot be null or empty. It should be in the form of " +
+            throw new InputValidationException(new ErrorResponse.ErrorResponseBuilder().setCode(400l)
+                    .setMessage("Activity Id cannot be null or empty. It should be in the form of " +
                             "'[ACTIVITY][_][any-positive-integer]' instead").build());
         }
         String[] splits = activityId.split("_");
-        if (splits == null || splits[0] == null || splits[0].isEmpty() || !"ACTIVITY".equals(splits[0]) ||
-                splits[1] == null || splits[0].isEmpty()) {
-            throw new InputValidationException(
-                    new ErrorResponse.ErrorResponseBuilder().setCode(400l).setMessage(
-                            "Activity Id should be in the form of '[ACTIVITY][_][any-positive-integer]'").build());
-        }
-        try {
-            Long.parseLong(splits[1]);
-        } catch (NumberFormatException e) {
-            throw new InputValidationException(
-                    new ErrorResponse.ErrorResponseBuilder().setCode(400l).setMessage(
-                            "Activity Id should be in the form of '[ACTIVITY][_][any-positive-integer]'").build());
+        if (splits.length > 1 && splits[0] != null && !splits[0].isEmpty() && "ACTIVITY".equals(splits[0])) {
+            try {
+                Long.parseLong(splits[1]);
+            } catch (NumberFormatException e) {
+                throw new InputValidationException(new ErrorResponse.ErrorResponseBuilder().setCode(400l)
+                        .setMessage(
+                                "Activity Id should be in the form of '[ACTIVITY][_][any-positive-integer]'")
+                        .build());
+            }
+        } else {
+            throw new InputValidationException(new ErrorResponse.ErrorResponseBuilder().setCode(400l)
+                    .setMessage("Activity Id should be in the form of '[ACTIVITY][_][any-positive-integer]'")
+                    .build());
         }
     }
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/ActivityProviderServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/ActivityProviderServiceImplTest.java
@@ -1,0 +1,226 @@
+package org.wso2.carbon.device.mgt.jaxrs.service.impl;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.testng.Assert;
+import org.testng.IObjectFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.ObjectFactory;
+import org.testng.annotations.Test;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.device.mgt.common.DeviceIdentifier;
+import org.wso2.carbon.device.mgt.common.authorization.DeviceAccessAuthorizationService;
+import org.wso2.carbon.device.mgt.common.operation.mgt.Activity;
+import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManagementException;
+import org.wso2.carbon.device.mgt.core.authorization.DeviceAccessAuthorizationServiceImpl;
+import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
+import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderServiceImpl;
+import org.wso2.carbon.device.mgt.jaxrs.common.ActivityIdList;
+import org.wso2.carbon.device.mgt.jaxrs.service.api.ActivityInfoProviderService;
+import org.wso2.carbon.device.mgt.jaxrs.service.api.DeviceManagementService;
+import org.wso2.carbon.device.mgt.jaxrs.service.impl.util.RequestValidationUtil;
+import org.wso2.carbon.device.mgt.jaxrs.util.DeviceMgtAPIUtils;
+import org.wso2.carbon.policy.mgt.core.util.PolicyManagerUtil;
+
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * This is a test class for {@link ActivityProviderServiceImpl}.
+ */
+@PowerMockIgnore("javax.ws.rs.*")
+@SuppressStaticInitializationFor({ "org.wso2.carbon.device.mgt.jaxrs.util.DeviceMgtAPIUtils",
+        "org.wso2.carbon.context.CarbonContext", "org.wso2.carbon.context.PrivilegedCarbonContext" })
+@PrepareForTest({ DeviceMgtAPIUtils.class, PolicyManagerUtil.class, PrivilegedCarbonContext.class })
+public class ActivityProviderServiceImplTest {
+
+    private static final Log log = LogFactory.getLog(ActivityProviderServiceImplTest.class);
+    private static final String TEST_ACTIVITY_ID = "ACTIVITY_1";
+    private static final String IF_MODIFIED_SINCE = "01Aug2018";
+    private static final String DEVICE_TYPE = "android";
+    private static final String DEVICE_ID = "1234567";
+    private static final String OPERATION_CODE = "111222";
+    private static final int OFFSET = 0;
+    private static final int LIMIT = 5;
+    private static final String TEST_ACTIVITY_ID_LIST = "ACTIVITY_1,ACTIVITY_2";
+    private static final List<String> idList = new ArrayList();
+    private static final List<Activity> activities = new ArrayList<>();
+    private static final ActivityIdList activityList = new ActivityIdList(TEST_ACTIVITY_ID_LIST);
+    private static final ActivityIdList activityListEmpty = new ActivityIdList("");
+
+    private List<String> idList1;
+    private Activity activity;
+    private List<Activity> activities1;
+
+    private DeviceManagementService deviceManagementService;
+    private DeviceAccessAuthorizationService deviceAccessAuthorizationService;
+    private DeviceManagementProviderService deviceManagementProviderService;
+    private ActivityInfoProviderService activityInfoProviderService;
+    private DeviceIdentifier deviceIdentifier;
+
+    @ObjectFactory
+    public IObjectFactory getObjectFactory() {
+        return new org.powermock.modules.testng.PowerMockObjectFactory();
+    }
+
+    @BeforeClass
+    public void init() {
+        log.info("Initializing ActivityProviderServiceImplTest tests");
+        initMocks(this);
+        this.deviceManagementProviderService = Mockito.mock(DeviceManagementProviderServiceImpl.class,
+                Mockito.RETURNS_MOCKS);
+        this.deviceIdentifier = new DeviceIdentifier();
+        this.deviceManagementService = new DeviceManagementServiceImpl();
+        this.activityInfoProviderService = new ActivityProviderServiceImpl();
+        this.deviceAccessAuthorizationService = Mockito.mock(DeviceAccessAuthorizationServiceImpl.class);
+        idList.add("ACTIVITY_1");
+        idList.add("ACTIVITY_2");
+        this.activity = new Activity();
+        Activity activity1 = new Activity();
+        Activity activity2 = new Activity();
+        activity1.setActivityId("ACTIVITY_1");
+        activity2.setActivityId("ACTIVITY_2");
+        activities.add(activity1);
+        activities.add(activity2);
+    }
+
+    @Test(description =
+            "This method tests  getting details of an activity with an admin user with an existing"
+                    + " activity Id")
+    public void testGetActivitiesWithValidAdminUserWithValidId() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService.getOperationByActivityId(TEST_ACTIVITY_ID))
+                .thenReturn(activity);
+        Response response = this.activityInfoProviderService.getActivity(TEST_ACTIVITY_ID, IF_MODIFIED_SINCE);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests getting details of an activity with an invalid admin user")
+    public void testGetActivitiesWithInvalidAdminUserWithValidId() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(false);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService.getOperationByActivityId(TEST_ACTIVITY_ID))
+                .thenReturn(activity);
+        Response response = this.activityInfoProviderService.getActivity(TEST_ACTIVITY_ID, IF_MODIFIED_SINCE);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.UNAUTHORIZED.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests getting details of an activity which does not exists")
+    public void testGetActivitiesWithNonExistingActivityID() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService.getOperationByActivityId(TEST_ACTIVITY_ID))
+                .thenReturn(null);
+        Response response = this.activityInfoProviderService.getActivity(TEST_ACTIVITY_ID, IF_MODIFIED_SINCE);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests the getActivity method under negative conditions.")
+    public void testGetActivitiesWithOperationManagementException() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService.getOperationByActivityId(Mockito.any())).thenThrow(
+                new OperationManagementException());
+        Response response = this.activityInfoProviderService.getActivity(TEST_ACTIVITY_ID, IF_MODIFIED_SINCE);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests getting details of list of given activity IDs")
+    public void testGetActivitiesWithActivityIdList() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService.getOperationByActivityIds(idList)).thenReturn(
+                activities);
+        Response response = this.activityInfoProviderService.getActivities(activityList);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests trying to get details activity IDs when call with empty list")
+    public void testGetActivitiesWithEmptyActivityIdList() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        Response response = this.activityInfoProviderService.getActivities(activityListEmpty);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests trying to get details of a list activity IDs which does not exists")
+    public void testGetActivitiesWithNonExistingActivityIdList() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService.getOperationByActivityIds(idList1)).thenReturn(
+                activities1);
+        Response response = this.activityInfoProviderService.getActivities(activityList);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests  getting details of an activity for a given device")
+    public void testGetActivitiesByDevice() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(this.deviceManagementProviderService
+                .getOperationByActivityIdAndDevice(TEST_ACTIVITY_ID, deviceIdentifier)).thenReturn(activity);
+        Response response = this.activityInfoProviderService.getActivityByDevice(TEST_ACTIVITY_ID,
+                DEVICE_TYPE, DEVICE_ID, IF_MODIFIED_SINCE);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests getting details of an activity for a given device")
+    public void testGetActivities() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(true);
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(
+                this.deviceManagementProviderService.getFilteredActivities(OPERATION_CODE, OFFSET, LIMIT))
+                .thenReturn(activities);
+        Response response = this.activityInfoProviderService.getActivities(OPERATION_CODE, OFFSET, LIMIT);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+    @Test(description = "This method tests getting details of an activity for a given device")
+    public void testGetActivitiesForInvalidUser() throws OperationManagementException {
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "isAdmin")).toReturn(false);
+        PowerMockito.stub(PowerMockito.method(RequestValidationUtil.class, "validateActivityId"));
+        PowerMockito.stub(PowerMockito.method(DeviceMgtAPIUtils.class, "getDeviceManagementService"))
+                .toReturn(this.deviceManagementProviderService);
+        Mockito.when(
+                this.deviceManagementProviderService.getFilteredActivities(OPERATION_CODE, OFFSET, LIMIT))
+                .thenReturn(activities);
+        Response response = this.activityInfoProviderService.getActivities(OPERATION_CODE, OFFSET, LIMIT);
+        Assert.assertNotNull(response);
+        Assert.assertEquals(response.getStatus(), Response.Status.UNAUTHORIZED.getStatusCode());
+        Mockito.reset(this.deviceManagementProviderService);
+    }
+
+}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/ActivityProviderServiceImplTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/test/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/ActivityProviderServiceImplTest.java
@@ -1,3 +1,22 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *   WSO2 Inc. licenses this file to you under the Apache License,
+ *   Version 2.0 (the "License"); you may not use this file except
+ *   in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing,
+ *   software distributed under the License is distributed on an
+ *   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *   KIND, either express or implied.  See the License for the
+ *   specific language governing permissions and limitations
+ *   under the License.
+ *
+ */
+
 package org.wso2.carbon.device.mgt.jaxrs.service.impl;
 
 import org.apache.commons.logging.Log;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/OperationManager.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/OperationManager.java
@@ -91,6 +91,8 @@ public interface OperationManager {
 
     Activity getOperationByActivityId(String activity) throws OperationManagementException;
 
+    List<Activity> getOperationByActivityIds(List<String> idList) throws OperationManagementException;
+
     Activity getOperationByActivityIdAndDevice(String activity, DeviceIdentifier deviceId)
             throws OperationManagementException;
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -737,6 +737,35 @@ public class OperationManagerImpl implements OperationManager {
         }
     }
 
+    @Override
+    public List<Activity> getOperationByActivityIds(List<String> activities)
+            throws OperationManagementException {
+        List<Integer> intActivities = new ArrayList<>();
+        for (String id : activities) {
+            int operationId = Integer.parseInt(
+                    id.replace(DeviceManagementConstants.OperationAttributes.ACTIVITY, ""));
+            if (operationId == 0) {
+                throw new IllegalArgumentException("Operation ID cannot be null or zero (0).");
+            } else {
+                intActivities.add(operationId);
+            }
+        }
+
+        try {
+            OperationManagementDAOFactory.openConnection();
+            return operationDAO.getActivityList(intActivities);
+        } catch (SQLException e) {
+            throw new OperationManagementException(
+                    "Error occurred while opening a connection to the data source.", e);
+        } catch (OperationManagementDAOException e) {
+            throw new OperationManagementException(
+                    "Error occurred while retrieving the operation with activity Id '" + activities
+                            .toString(), e);
+        } finally {
+            OperationManagementDAOFactory.closeConnection();
+        }
+    }
+
     public Activity getOperationByActivityIdAndDevice(String activity, DeviceIdentifier deviceId) throws OperationManagementException {
         // This parses the operation id from activity id (ex : ACTIVITY_23) and converts to the integer.
         int operationId = Integer.parseInt(

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -740,20 +740,20 @@ public class OperationManagerImpl implements OperationManager {
     @Override
     public List<Activity> getOperationByActivityIds(List<String> activities)
             throws OperationManagementException {
-        List<Integer> intActivities = new ArrayList<>();
+        List<Integer> operationIds = new ArrayList<>();
         for (String id : activities) {
             int operationId = Integer.parseInt(
                     id.replace(DeviceManagementConstants.OperationAttributes.ACTIVITY, ""));
             if (operationId == 0) {
                 throw new IllegalArgumentException("Operation ID cannot be null or zero (0).");
             } else {
-                intActivities.add(operationId);
+                operationIds.add(operationId);
             }
         }
 
         try {
             OperationManagementDAOFactory.openConnection();
-            return operationDAO.getActivityList(intActivities);
+            return operationDAO.getActivityList(operationIds);
         } catch (SQLException e) {
             throw new OperationManagementException(
                     "Error occurred while opening a connection to the data source.", e);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/OperationDAO.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/OperationDAO.java
@@ -61,6 +61,8 @@ public interface OperationDAO {
 
     Activity getActivity(int operationId) throws OperationManagementDAOException;
 
+    List<Activity> getActivityList(List<Integer> operationIds) throws OperationManagementDAOException;
+
     Activity getActivityByDevice(int operationId, int deviceId) throws OperationManagementDAOException;
 
     List<Activity> getActivitiesUpdatedAfter(long timestamp, int limit, int offset) throws OperationManagementDAOException;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -344,8 +344,8 @@ public class GenericOperationDAOImpl implements OperationDAO {
             int enrolmentId = 0;
             int responseId = 0;
             ActivityStatus activityStatus = new ActivityStatus();
-            activity = new Activity();
             while (rs.next()) {
+                activity = new Activity();
 
                 if (operationId != rs.getInt("OPERATION_ID")) {
                     activities.add(activity);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -374,7 +374,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                                 new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
 
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -404,7 +404,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                         activityStatus.setUpdatedTimestamp(
                                 new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -415,7 +415,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                 }
 
                 if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID") && rs.getTimestamp(
-                        "RECEIVED_TIMESTAMP") != (null)) {
+                        "RECEIVED_TIMESTAMP") != null) {
                     activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
                     responseId = rs.getInt("OP_RES_ID");
                 }
@@ -609,7 +609,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                                 rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
 
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -639,7 +639,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                         activityStatus.setUpdatedTimestamp(new java.util.Date(
                                 rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -650,7 +650,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                 }
 
                 if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID")) {
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -796,7 +796,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                                 rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
 
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -826,7 +826,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                         activityStatus.setUpdatedTimestamp(new java.util.Date(
                                 rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -837,7 +837,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                 }
 
                 if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID")) {
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -309,6 +309,133 @@ public class GenericOperationDAOImpl implements OperationDAO {
         return activity;
     }
 
+
+    @Override
+    public List<Activity> getActivityList(List<Integer> activityIds) throws OperationManagementDAOException {
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        Activity activity;
+        List<Activity> activities = new ArrayList<>();
+        Object[] data = activityIds.toArray();
+
+        try {
+            Connection conn = OperationManagementDAOFactory.getConnection();
+            String sql =
+                    "SELECT eom.ENROLMENT_ID, eom.OPERATION_ID, eom.ID AS EOM_MAPPING_ID, "
+                            + "dor.ID AS OP_RES_ID, de.DEVICE_ID, d.DEVICE_IDENTIFICATION, d.DEVICE_TYPE_ID, "
+                            + "dt.NAME AS DEVICE_TYPE_NAME, eom.STATUS, eom.CREATED_TIMESTAMP, "
+                            + "eom.UPDATED_TIMESTAMP, op.OPERATION_CODE, op.TYPE AS OPERATION_TYPE, "
+                            + "dor.OPERATION_RESPONSE, dor.RECEIVED_TIMESTAMP FROM "
+                            + "DM_ENROLMENT_OP_MAPPING eom INNER JOIN DM_OPERATION op "
+                            + "ON op.ID=eom.OPERATION_ID INNER JOIN DM_ENROLMENT de "
+                            + "ON de.ID=eom.ENROLMENT_ID INNER JOIN DM_DEVICE d ON d.ID=de.DEVICE_ID \n"
+                            + "INNER JOIN DM_DEVICE_TYPE dt ON dt.ID=d.DEVICE_TYPE_ID\n"
+                            + "LEFT JOIN DM_DEVICE_OPERATION_RESPONSE dor ON dor.ENROLMENT_ID=de.id \n"
+                            + "AND dor.OPERATION_ID = eom.OPERATION_ID WHERE eom.OPERATION_ID "
+                            + "IN (SELECT * FROM TABLE(x INT = ?)) AND de.TENANT_ID = ?";
+
+            stmt = conn.prepareStatement(sql);
+            stmt.setObject(1, data);
+
+            stmt.setInt(2, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+            rs = stmt.executeQuery();
+
+            int operationId = 0;
+            int enrolmentId = 0;
+            int responseId = 0;
+            ActivityStatus activityStatus = new ActivityStatus();
+            activity = new Activity();
+            while (rs.next()) {
+
+                if (operationId != rs.getInt("OPERATION_ID")) {
+                    activities.add(activity);
+                    List<ActivityStatus> statusList = new ArrayList<>();
+                    activityStatus = new ActivityStatus();
+
+                    operationId = rs.getInt("OPERATION_ID");
+                    enrolmentId = rs.getInt("ENROLMENT_ID");
+
+                    activity.setType(Activity.Type.valueOf(rs.getString("OPERATION_TYPE")));
+                    activity.setCreatedTimeStamp(
+                            new java.util.Date(rs.getLong(("CREATED_TIMESTAMP")) * 1000).toString());
+                    activity.setCode(rs.getString("OPERATION_CODE"));
+
+                    DeviceIdentifier deviceIdentifier = new DeviceIdentifier();
+                    deviceIdentifier.setId(rs.getString("DEVICE_IDENTIFICATION"));
+                    deviceIdentifier.setType(rs.getString("DEVICE_TYPE_NAME"));
+
+                    activityStatus.setDeviceIdentifier(deviceIdentifier);
+
+                    activityStatus.setStatus(ActivityStatus.Status.valueOf(rs.getString("STATUS")));
+
+                    List<OperationResponse> operationResponses = new ArrayList<>();
+                    if (rs.getInt("UPDATED_TIMESTAMP") != 0) {
+                        activityStatus.setUpdatedTimestamp(
+                                new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
+
+                    }
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                    activityStatus.setResponses(operationResponses);
+                    statusList.add(activityStatus);
+                    activity.setActivityStatus(statusList);
+                    activity.setActivityId(OperationDAOUtil.getActivityId(rs.getInt("OPERATION_ID")));
+                }
+
+                if (operationId == rs.getInt("OPERATION_ID") && enrolmentId != rs.getInt("ENROLMENT_ID")) {
+                    activityStatus = new ActivityStatus();
+
+                    activity.setType(Activity.Type.valueOf(rs.getString("OPERATION_TYPE")));
+                    activity.setCreatedTimeStamp(
+                            new java.util.Date(rs.getLong(("CREATED_TIMESTAMP")) * 1000).toString());
+                    activity.setCode(rs.getString("OPERATION_CODE"));
+
+                    DeviceIdentifier deviceIdentifier = new DeviceIdentifier();
+                    deviceIdentifier.setId(rs.getString("DEVICE_IDENTIFICATION"));
+                    deviceIdentifier.setType(rs.getString("DEVICE_TYPE_NAME"));
+                    activityStatus.setDeviceIdentifier(deviceIdentifier);
+
+                    activityStatus.setStatus(ActivityStatus.Status.valueOf(rs.getString("STATUS")));
+
+                    List<OperationResponse> operationResponses = new ArrayList<>();
+                    if (rs.getInt("UPDATED_TIMESTAMP") != 0) {
+                        activityStatus.setUpdatedTimestamp(
+                                new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
+                    }
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                    activityStatus.setResponses(operationResponses);
+                    activity.getActivityStatus().add(activityStatus);
+
+                    enrolmentId = rs.getInt("ENROLMENT_ID");
+                }
+
+                if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID") && rs.getTimestamp(
+                        "RECEIVED_TIMESTAMP") != (null)) {
+                    activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
+                    responseId = rs.getInt("OP_RES_ID");
+                }
+            }
+
+        } catch (SQLException e) {
+            throw new OperationManagementDAOException(
+                    "Error occurred while getting the operation details from " + "the database.", e);
+        } catch (ClassNotFoundException e) {
+            throw new OperationManagementDAOException(
+                    "Error occurred while converting the operation response to string.", e);
+        } catch (IOException e) {
+            throw new OperationManagementDAOException(
+                    "IO exception occurred while converting the operations responses.", e);
+        } finally {
+            OperationManagementDAOUtil.cleanupResources(stmt, rs);
+        }
+        return activities;
+    }
+
     public Activity getActivityByDevice(int operationId, int deviceId) throws OperationManagementDAOException {
 
         PreparedStatement stmt = null;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/operation/MySQLOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/operation/MySQLOperationDAOImpl.java
@@ -78,6 +78,133 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
     }
 
 
+    public List<Activity> getActivityList(List<Integer> activityIds) throws OperationManagementDAOException {
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        Activity activity;
+        List<Activity> activities = new ArrayList<>();
+        Object[] data = activityIds.toArray();
+
+        try {
+            Connection conn = OperationManagementDAOFactory.getConnection();
+            String sql =
+                    "SELECT eom.ENROLMENT_ID, eom.OPERATION_ID, eom.ID AS EOM_MAPPING_ID, "
+                            + "dor.ID AS OP_RES_ID, de.DEVICE_ID, d.DEVICE_IDENTIFICATION, d.DEVICE_TYPE_ID, "
+                            + "dt.NAME AS DEVICE_TYPE_NAME, eom.STATUS, eom.CREATED_TIMESTAMP, "
+                            + "eom.UPDATED_TIMESTAMP, op.OPERATION_CODE, op.TYPE AS OPERATION_TYPE, "
+                            + "dor.OPERATION_RESPONSE, dor.RECEIVED_TIMESTAMP FROM "
+                            + "DM_ENROLMENT_OP_MAPPING eom INNER JOIN DM_OPERATION op "
+                            + "ON op.ID=eom.OPERATION_ID INNER JOIN DM_ENROLMENT de "
+                            + "ON de.ID=eom.ENROLMENT_ID INNER JOIN DM_DEVICE d ON d.ID=de.DEVICE_ID \n"
+                            + "INNER JOIN DM_DEVICE_TYPE dt ON dt.ID=d.DEVICE_TYPE_ID\n"
+                            + "LEFT JOIN DM_DEVICE_OPERATION_RESPONSE dor ON dor.ENROLMENT_ID=de.id \n"
+                            + "AND dor.OPERATION_ID = eom.OPERATION_ID WHERE eom.OPERATION_ID "
+                            + "IN (SELECT * FROM TABLE(x INT = ?)) AND de.TENANT_ID = ?";
+
+            stmt = conn.prepareStatement(sql);
+            stmt.setObject(1, data);
+
+            stmt.setInt(2, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+            rs = stmt.executeQuery();
+
+            int operationId = 0;
+            int enrolmentId = 0;
+            int responseId = 0;
+            ActivityStatus activityStatus = new ActivityStatus();
+            activity = new Activity();
+            while (rs.next()) {
+
+                if (operationId != rs.getInt("OPERATION_ID")) {
+                    activities.add(activity);
+                    List<ActivityStatus> statusList = new ArrayList<>();
+                    activityStatus = new ActivityStatus();
+
+                    operationId = rs.getInt("OPERATION_ID");
+                    enrolmentId = rs.getInt("ENROLMENT_ID");
+
+                    activity.setType(Activity.Type.valueOf(rs.getString("OPERATION_TYPE")));
+                    activity.setCreatedTimeStamp(
+                            new java.util.Date(rs.getLong(("CREATED_TIMESTAMP")) * 1000).toString());
+                    activity.setCode(rs.getString("OPERATION_CODE"));
+
+                    DeviceIdentifier deviceIdentifier = new DeviceIdentifier();
+                    deviceIdentifier.setId(rs.getString("DEVICE_IDENTIFICATION"));
+                    deviceIdentifier.setType(rs.getString("DEVICE_TYPE_NAME"));
+
+                    activityStatus.setDeviceIdentifier(deviceIdentifier);
+
+                    activityStatus.setStatus(ActivityStatus.Status.valueOf(rs.getString("STATUS")));
+
+                    List<OperationResponse> operationResponses = new ArrayList<>();
+                    if (rs.getInt("UPDATED_TIMESTAMP") != 0) {
+                        activityStatus.setUpdatedTimestamp(
+                                new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
+
+                    }
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                    activityStatus.setResponses(operationResponses);
+                    statusList.add(activityStatus);
+                    activity.setActivityStatus(statusList);
+                    activity.setActivityId(OperationDAOUtil.getActivityId(rs.getInt("OPERATION_ID")));
+                }
+
+                if (operationId == rs.getInt("OPERATION_ID") && enrolmentId != rs.getInt("ENROLMENT_ID")) {
+                    activityStatus = new ActivityStatus();
+
+                    activity.setType(Activity.Type.valueOf(rs.getString("OPERATION_TYPE")));
+                    activity.setCreatedTimeStamp(
+                            new java.util.Date(rs.getLong(("CREATED_TIMESTAMP")) * 1000).toString());
+                    activity.setCode(rs.getString("OPERATION_CODE"));
+
+                    DeviceIdentifier deviceIdentifier = new DeviceIdentifier();
+                    deviceIdentifier.setId(rs.getString("DEVICE_IDENTIFICATION"));
+                    deviceIdentifier.setType(rs.getString("DEVICE_TYPE_NAME"));
+                    activityStatus.setDeviceIdentifier(deviceIdentifier);
+
+                    activityStatus.setStatus(ActivityStatus.Status.valueOf(rs.getString("STATUS")));
+
+                    List<OperationResponse> operationResponses = new ArrayList<>();
+                    if (rs.getInt("UPDATED_TIMESTAMP") != 0) {
+                        activityStatus.setUpdatedTimestamp(
+                                new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
+                    }
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                    activityStatus.setResponses(operationResponses);
+                    activity.getActivityStatus().add(activityStatus);
+
+                    enrolmentId = rs.getInt("ENROLMENT_ID");
+                }
+
+                if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID") && rs.getTimestamp(
+                        "RECEIVED_TIMESTAMP") != (null)) {
+                    activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
+                    responseId = rs.getInt("OP_RES_ID");
+                }
+            }
+
+        } catch (SQLException e) {
+            throw new OperationManagementDAOException(
+                    "Error occurred while getting the operation details from " + "the database.", e);
+        } catch (ClassNotFoundException e) {
+            throw new OperationManagementDAOException(
+                    "Error occurred while converting the operation response to string.", e);
+        } catch (IOException e) {
+            throw new OperationManagementDAOException(
+                    "IO exception occurred while converting the operations responses.", e);
+        } finally {
+            OperationManagementDAOUtil.cleanupResources(stmt, rs);
+        }
+        return activities;
+    }
+
+
+
     @Override
     public List<Activity> getActivitiesUpdatedAfter(long timestamp, int limit,
                                                     int offset) throws OperationManagementDAOException {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/operation/MySQLOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/operation/MySQLOperationDAOImpl.java
@@ -77,42 +77,48 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
         return isUpdated;
     }
 
-
+    @Override
     public List<Activity> getActivityList(List<Integer> activityIds) throws OperationManagementDAOException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         Activity activity;
         List<Activity> activities = new ArrayList<>();
-        Object[] data = activityIds.toArray();
 
         try {
             Connection conn = OperationManagementDAOFactory.getConnection();
-            String sql =
-                    "SELECT eom.ENROLMENT_ID, eom.OPERATION_ID, eom.ID AS EOM_MAPPING_ID, "
-                            + "dor.ID AS OP_RES_ID, de.DEVICE_ID, d.DEVICE_IDENTIFICATION, d.DEVICE_TYPE_ID, "
-                            + "dt.NAME AS DEVICE_TYPE_NAME, eom.STATUS, eom.CREATED_TIMESTAMP, "
-                            + "eom.UPDATED_TIMESTAMP, op.OPERATION_CODE, op.TYPE AS OPERATION_TYPE, "
-                            + "dor.OPERATION_RESPONSE, dor.RECEIVED_TIMESTAMP FROM "
-                            + "DM_ENROLMENT_OP_MAPPING eom INNER JOIN DM_OPERATION op "
-                            + "ON op.ID=eom.OPERATION_ID INNER JOIN DM_ENROLMENT de "
-                            + "ON de.ID=eom.ENROLMENT_ID INNER JOIN DM_DEVICE d ON d.ID=de.DEVICE_ID \n"
-                            + "INNER JOIN DM_DEVICE_TYPE dt ON dt.ID=d.DEVICE_TYPE_ID\n"
-                            + "LEFT JOIN DM_DEVICE_OPERATION_RESPONSE dor ON dor.ENROLMENT_ID=de.id \n"
-                            + "AND dor.OPERATION_ID = eom.OPERATION_ID WHERE eom.OPERATION_ID "
-                            + "IN (SELECT * FROM TABLE(x INT = ?)) AND de.TENANT_ID = ?";
 
-            stmt = conn.prepareStatement(sql);
-            stmt.setObject(1, data);
+            String sql1 = "SELECT eom.ENROLMENT_ID, eom.OPERATION_ID, eom.ID AS EOM_MAPPING_ID, "
+                    + "dor.ID AS OP_RES_ID, de.DEVICE_ID, d.DEVICE_IDENTIFICATION, d.DEVICE_TYPE_ID, "
+                    + "dt.NAME AS DEVICE_TYPE_NAME, eom.STATUS, eom.CREATED_TIMESTAMP, "
+                    + "eom.UPDATED_TIMESTAMP, op.OPERATION_CODE, op.TYPE AS OPERATION_TYPE, "
+                    + "dor.OPERATION_RESPONSE, dor.RECEIVED_TIMESTAMP FROM "
+                    + "DM_ENROLMENT_OP_MAPPING eom INNER JOIN DM_OPERATION op "
+                    + "ON op.ID=eom.OPERATION_ID INNER JOIN DM_ENROLMENT de "
+                    + "ON de.ID=eom.ENROLMENT_ID INNER JOIN DM_DEVICE d ON d.ID=de.DEVICE_ID \n"
+                    + "INNER JOIN DM_DEVICE_TYPE dt ON dt.ID=d.DEVICE_TYPE_ID\n"
+                    + "LEFT JOIN DM_DEVICE_OPERATION_RESPONSE dor ON dor.ENROLMENT_ID=de.id \n"
+                    + "AND dor.OPERATION_ID = eom.OPERATION_ID WHERE eom.OPERATION_ID " + "IN (";
 
-            stmt.setInt(2, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < activityIds.size(); i++) {
+                builder.append("?,");
+            }
+            sql1 += builder.deleteCharAt(builder.length() - 1).toString() + ") AND de.TENANT_ID = ?";
+            stmt = conn.prepareStatement(sql1);
+            int i;
+            for (i = 0; i < activityIds.size(); i++) {
+                stmt.setInt(i + 1, activityIds.get(i));
+            }
+            stmt.setInt(i + 1, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+
             rs = stmt.executeQuery();
 
             int operationId = 0;
             int enrolmentId = 0;
             int responseId = 0;
             ActivityStatus activityStatus = new ActivityStatus();
-            activity = new Activity();
             while (rs.next()) {
+                activity = new Activity();
 
                 if (operationId != rs.getInt("OPERATION_ID")) {
                     activities.add(activity);
@@ -361,5 +367,15 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
             OperationManagementDAOUtil.cleanupResources(stmt, rs);
         }
         return activities;
+    }
+
+    private Integer[] getIntArrayOfActivityIds(List<Integer> activityIds) {
+        Integer[] arr = new Integer[activityIds.size()];
+        int x = 0;
+        for (Integer activityId : activityIds) {
+            arr[x] = activityId;
+            x++;
+        }
+        return arr;
     }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/operation/MySQLOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/operation/MySQLOperationDAOImpl.java
@@ -147,7 +147,7 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
                                 new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
 
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -177,7 +177,7 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
                         activityStatus.setUpdatedTimestamp(
                                 new java.util.Date(rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -188,7 +188,7 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
                 }
 
                 if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID") && rs.getTimestamp(
-                        "RECEIVED_TIMESTAMP") != (null)) {
+                        "RECEIVED_TIMESTAMP") != null) {
                     activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
                     responseId = rs.getInt("OP_RES_ID");
                 }
@@ -309,7 +309,7 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
                                 rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
 
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -339,7 +339,7 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
                         activityStatus.setUpdatedTimestamp(new java.util.Date(
                                 rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
                     }
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }
@@ -350,7 +350,7 @@ public class MySQLOperationDAOImpl extends GenericOperationDAOImpl {
                 }
 
                 if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID")) {
-                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != null) {
                         activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
                         responseId = rs.getInt("OP_RES_ID");
                     }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
@@ -564,6 +564,8 @@ public interface DeviceManagementProviderService {
 
     Activity getOperationByActivityId(String activity) throws OperationManagementException;
 
+    List<Activity> getOperationByActivityIds(List<String> idList) throws OperationManagementException;
+
     Activity getOperationByActivityIdAndDevice(String activity, DeviceIdentifier deviceId) throws OperationManagementException;
 
     List<Activity> getActivitiesUpdatedAfter(long timestamp, int limit, int offset) throws OperationManagementException;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -1473,6 +1473,11 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
         return DeviceManagementDataHolder.getInstance().getOperationManager().getOperationByActivityId(activity);
     }
 
+    @Override
+    public List<Activity> getOperationByActivityIds(List<String> idList) throws OperationManagementException{
+        return DeviceManagementDataHolder.getInstance().getOperationManager().getOperationByActivityIds(idList);
+    }
+
     public Activity getOperationByActivityIdAndDevice(String activity, DeviceIdentifier deviceId) throws OperationManagementException {
         return DeviceManagementDataHolder.getInstance().getOperationManager().getOperationByActivityIdAndDevice(activity, deviceId);
     }


### PR DESCRIPTION
## Purpose
> The current activity info provider API has two API resources which allows to retrieve activity information without passing the device type, or the activity type. These two allows to retrieve information about single activity by passing the necessary activity ID or allows to retrieve the all the activity information at once. Hence, this API resource will accept an array of activity IDs where it can query information of 1 - 10 activities at once: Resolves https://github.com/wso2/product-iots/issues/1531, https://github.com/wso2/product-iots/issues/1607

## Goals
> Add new Activity Info Provider API resource which accept an array of activity IDs

## User stories
> When a user needs to get information of set of activities at once then he need to call the get activities API with relevant activity IDs. For an example let's say someone triggers RING API 5 times every 5 minutes. Then 5 activity IDs will be received for 5 operations. If somebody needs to get the status of all five ring operations at once, GET /activities/ids API can be called with the related activity Id list at once instead of calling GET /activity API 5 times.

## Automation tests
 - Unit tests 
   > Covered with the class ActivityProviderServiceImplTest.java

## Security checks
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
 