### PR TITLE
Improvements to policy monitoring framework

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/general/GeneralConfig.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/general/GeneralConfig.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.wso2.carbon.device.mgt.common.general;
+
+public class GeneralConfig {
+
+    private boolean policyMonitoringEnabled;
+
+    public boolean isPolicyMonitoringEnabled() {
+        return policyMonitoringEnabled;
+    }
+
+    public void setPolicyMonitoringEnabled(boolean policyMonitoringEnabled) {
+        this.policyMonitoringEnabled = policyMonitoringEnabled;
+    }
+}
+

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/spi/DeviceManagementService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/spi/DeviceManagementService.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.device.mgt.common.spi;
 
 import org.wso2.carbon.device.mgt.common.*;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -51,5 +52,7 @@ public interface DeviceManagementService {
     PullNotificationSubscriber getPullNotificationSubscriber();
 
     DeviceStatusTaskPluginConfig getDeviceStatusTaskPluginConfig();
+
+    GeneralConfig getGeneralConfig();
 
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
@@ -522,6 +522,8 @@ public interface DeviceManagementProviderService {
 
     List<String> getAvailableDeviceTypes() throws DeviceManagementException;
 
+    List<String> getPolicyMonitoringEnableDeviceTypes() throws DeviceManagementException;
+
     boolean updateDeviceInfo(DeviceIdentifier deviceIdentifier, Device device) throws DeviceManagementException;
 
     boolean setOwnership(DeviceIdentifier deviceId, String ownershipType) throws DeviceManagementException;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -1178,6 +1178,29 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
     }
 
     @Override
+    public List<String> getPolicyMonitoringEnableDeviceTypes() throws DeviceManagementException {
+
+        List<String> deviceTypes = this.getAvailableDeviceTypes();
+        List<String> deviceTyepsToMonitor = new ArrayList<>();
+        int tenantId = this.getTenantId();
+        Map<DeviceTypeServiceIdentifier, DeviceManagementService> registeredTypes =
+                pluginRepository.getAllDeviceManagementServices(tenantId);
+
+        List<DeviceManagementService> services = new ArrayList<>(registeredTypes.values());
+        for (DeviceManagementService deviceType : services) {
+            if (deviceType != null && deviceType.getGeneralConfig() != null &&
+                    deviceType.getGeneralConfig().isPolicyMonitoringEnabled()) {
+                for (String type : deviceTypes) {
+                    if (type.equalsIgnoreCase(deviceType.getType())) {
+                        deviceTyepsToMonitor.add(type);
+                    }
+                }
+            }
+        }
+        return deviceTyepsToMonitor;
+    }
+
+    @Override
     public boolean updateDeviceInfo(DeviceIdentifier deviceId, Device device) throws DeviceManagementException {
         if (deviceId == null || device == null) {
             String msg = "Received incomplete data for updateDeviceInfo";
@@ -1489,13 +1512,13 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
     }
 
     @Override
-    public List<Activity> getFilteredActivities(String operationCode, int limit, int offset) throws OperationManagementException{
+    public List<Activity> getFilteredActivities(String operationCode, int limit, int offset) throws OperationManagementException {
         limit = DeviceManagerUtil.validateActivityListPageSize(limit);
         return DeviceManagementDataHolder.getInstance().getOperationManager().getFilteredActivities(operationCode, limit, offset);
     }
 
     @Override
-    public int getTotalCountOfFilteredActivities(String operationCode) throws OperationManagementException{
+    public int getTotalCountOfFilteredActivities(String operationCode) throws OperationManagementException {
         return DeviceManagementDataHolder.getInstance().getOperationManager().getTotalCountOfFilteredActivities(operationCode);
     }
 
@@ -2565,7 +2588,7 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
         }
         try {
             DeviceManagementDAOFactory.openConnection();
-            return deviceDAO.findGeoClusters(southWest,northEast,geohashLength,this.getTenantId());
+            return deviceDAO.findGeoClusters(southWest, northEast, geohashLength, this.getTenantId());
         } catch (DeviceManagementDAOException e) {
             String msg = "Error occurred while retrieving the geo clusters.";
             log.error(msg, e);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -1181,7 +1181,7 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
     public List<String> getPolicyMonitoringEnableDeviceTypes() throws DeviceManagementException {
 
         List<String> deviceTypes = this.getAvailableDeviceTypes();
-        List<String> deviceTyepsToMonitor = new ArrayList<>();
+        List<String> deviceTypesToMonitor = new ArrayList<>();
         int tenantId = this.getTenantId();
         Map<DeviceTypeServiceIdentifier, DeviceManagementService> registeredTypes =
                 pluginRepository.getAllDeviceManagementServices(tenantId);
@@ -1192,12 +1192,12 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
                     deviceType.getGeneralConfig().isPolicyMonitoringEnabled()) {
                 for (String type : deviceTypes) {
                     if (type.equalsIgnoreCase(deviceType.getType())) {
-                        deviceTyepsToMonitor.add(type);
+                        deviceTypesToMonitor.add(type);
                     }
                 }
             }
         }
-        return deviceTyepsToMonitor;
+        return deviceTypesToMonitor;
     }
 
     @Override

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/TestDeviceManagementService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/TestDeviceManagementService.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.device.mgt.core;
 
 import org.wso2.carbon.device.mgt.common.*;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -106,6 +107,11 @@ public class TestDeviceManagementService implements DeviceManagementService {
 
     @Override
     public DeviceStatusTaskPluginConfig getDeviceStatusTaskPluginConfig() {
+        return null;
+    }
+
+    @Override
+    public GeneralConfig getGeneralConfig() {
         return null;
     }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/DeviceTypeManagerService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/DeviceTypeManagerService.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.device.mgt.common.ProvisioningConfig;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.ConfigurationEntry;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.PlatformConfiguration;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -69,6 +70,7 @@ public class DeviceTypeManagerService implements DeviceManagementService {
     private InitialOperationConfig initialOperationConfig;
     private PullNotificationSubscriber pullNotificationSubscriber;
     private DeviceStatusTaskPluginConfig deviceStatusTaskPluginConfig;
+    private GeneralConfig generalConfig;
 
     public DeviceTypeManagerService(DeviceTypeConfigIdentifier deviceTypeConfigIdentifier,
                                     DeviceTypeConfiguration deviceTypeConfiguration) {
@@ -84,6 +86,7 @@ public class DeviceTypeManagerService implements DeviceManagementService {
         this.setDeviceStatusTaskPluginConfig(deviceTypeConfiguration.getDeviceStatusTaskConfiguration());
         this.setPolicyMonitoringManager(deviceTypeConfiguration.getPolicyMonitoring());
         this.setPullNotificationSubscriber(deviceTypeConfiguration.getPullNotificationSubscriberConfig());
+        this.setGeneralConfig(deviceTypeConfiguration);
     }
 
     @Override
@@ -92,7 +95,7 @@ public class DeviceTypeManagerService implements DeviceManagementService {
     }
 
     @Override
-    public OperationMonitoringTaskConfig getOperationMonitoringConfig(){
+    public OperationMonitoringTaskConfig getOperationMonitoringConfig() {
         return operationMonitoringConfigs;
     }
 
@@ -193,6 +196,11 @@ public class DeviceTypeManagerService implements DeviceManagementService {
         return deviceStatusTaskPluginConfig;
     }
 
+    @Override
+    public GeneralConfig getGeneralConfig() {
+        return generalConfig;
+    }
+
     private void setProvisioningConfig(String tenantDomain, DeviceTypeConfiguration deviceTypeConfiguration) {
         if (deviceTypeConfiguration.getProvisioningConfig() != null) {
             boolean sharedWithAllTenants = deviceTypeConfiguration.getProvisioningConfig().isSharedWithAllTenants();
@@ -262,6 +270,14 @@ public class DeviceTypeManagerService implements DeviceManagementService {
                         (className, pullNotificationSubscriberConfig.getConfigProperties());
                 this.pullNotificationSubscriber = pullNotificationSubscriberLoader.getPullNotificationSubscriber();
             }
+        }
+    }
+
+
+    public void setGeneralConfig(DeviceTypeConfiguration deviceTypeConfiguration) {
+        this.generalConfig = new GeneralConfig();
+        if (deviceTypeConfiguration.getPolicyMonitoring() != null) {
+            this.generalConfig.setPolicyMonitoringEnabled(deviceTypeConfiguration.getPolicyMonitoring().isEnabled());
         }
     }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/InitialOperationConfig.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/InitialOperationConfig.java
@@ -33,7 +33,7 @@ public class InitialOperationConfig {
         return operations;
     }
 
-    public void setOperationsll(List<String> operations) {
+    public void setOperations(List<String> operations) {
         this.operations = operations;
     }
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
@@ -52,8 +52,7 @@ public class PolicyMonitoring {
     protected String value;
     @XmlAttribute(name = "enabled")
     protected boolean enabled;
-
-
+    
     /**
      * Gets the value of the value property.
      * 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
@@ -52,8 +52,6 @@ public class PolicyMonitoring {
     protected String value;
     @XmlAttribute(name = "enabled")
     protected boolean enabled;
-//    protected String policyEvaluationPoint;
-//    protected String cacheEnable;
 
 
     /**

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
@@ -52,6 +52,9 @@ public class PolicyMonitoring {
     protected String value;
     @XmlAttribute(name = "enabled")
     protected boolean enabled;
+//    protected String policyEvaluationPoint;
+//    protected String cacheEnable;
+
 
     /**
      * Gets the value of the value property.

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/main/java/org/wso2/carbon/device/mgt/extensions/device/type/template/config/PolicyMonitoring.java
@@ -52,7 +52,7 @@ public class PolicyMonitoring {
     protected String value;
     @XmlAttribute(name = "enabled")
     protected boolean enabled;
-    
+
     /**
      * Gets the value of the value property.
      * 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/test/java/org/wso2/carbon/device/mgt/extensions/device/type/template/DeviceTypeManagerServiceTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/test/java/org/wso2/carbon/device/mgt/extensions/device/type/template/DeviceTypeManagerServiceTest.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.device.mgt.common.ProvisioningConfig;
 import org.wso2.carbon.device.mgt.common.ProvisioningConfig;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.ConfigurationEntry;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.PlatformConfiguration;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.license.mgt.License;
 import org.wso2.carbon.device.mgt.common.license.mgt.LicenseManagementException;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -76,6 +77,7 @@ public class DeviceTypeManagerServiceTest {
     private Method populatePushNotificationConfig;
     private Method setPolicyMonitoringManager;
     private Method setPullNotificationSubscriber;
+    private Method setGeneralConfig;
 
     @BeforeClass
     public void setup() throws NoSuchMethodException, SAXException, JAXBException, ParserConfigurationException,
@@ -102,9 +104,18 @@ public class DeviceTypeManagerServiceTest {
                 .getDeclaredMethod("setPullNotificationSubscriber", PullNotificationSubscriberConfig.class);
         setPullNotificationSubscriber.setAccessible(true);
 
+        setGeneralConfig = DeviceTypeManagerService.class
+                .getDeclaredMethod("setGeneralConfig", DeviceTypeConfiguration.class);
+        setGeneralConfig.setAccessible(true);
+
         Field deviceStatusTaskPluginConfig = DeviceTypeManagerService.class
                 .getDeclaredField("deviceStatusTaskPluginConfig");
         deviceStatusTaskPluginConfig.setAccessible(true);
+
+
+        Field generalConfig = DeviceTypeManagerService.class
+                .getDeclaredField("generalConfig");
+        generalConfig.setAccessible(true);
 
         Field operationMonitoringConfigs = DeviceTypeManagerService.class
                 .getDeclaredField("operationMonitoringConfigs");

--- a/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/test/resources/device-types/arduino.xml
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.extensions/src/test/resources/device-types/arduino.xml
@@ -30,6 +30,7 @@
         </Feature>
     </Features>
 
+    <PolicyMonitoring enabled="false"/>
     <ProvisioningConfig>
         <SharedWithAllTenants>true</SharedWithAllTenants>
     </ProvisioningConfig>

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImpl.java
@@ -209,7 +209,12 @@ public class PolicyManagerServiceImpl implements PolicyManagerService {
 
         List<ComplianceFeature> complianceFeatures =
                 monitoringManager.checkPolicyCompliance(deviceIdentifier, response);
-        return !(complianceFeatures == null || complianceFeatures.isEmpty());
+        if(complianceFeatures == null || complianceFeatures.isEmpty()) {
+            return true;
+        } else {
+            return false;
+        }
+
     }
 
     @Override

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/dao/impl/MonitoringDAOImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/dao/impl/MonitoringDAOImpl.java
@@ -242,6 +242,9 @@ public class MonitoringDAOImpl implements MonitoringDAO {
         PreparedStatement stmt = null;
         ResultSet resultSet = null;
         NonComplianceData complianceData = new NonComplianceData();
+        // Setting the initial compliance status as true;
+//        complianceData.setStatus(true);
+
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
 
         try {

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/dao/impl/MonitoringDAOImpl.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/main/java/org/wso2/carbon/policy/mgt/core/dao/impl/MonitoringDAOImpl.java
@@ -242,8 +242,6 @@ public class MonitoringDAOImpl implements MonitoringDAO {
         PreparedStatement stmt = null;
         ResultSet resultSet = null;
         NonComplianceData complianceData = new NonComplianceData();
-        // Setting the initial compliance status as true;
-//        complianceData.setStatus(true);
 
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
 

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
@@ -254,8 +254,8 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
         List<Device> deviceList = new ArrayList<>();
         deviceList.add(device);
 
-        MonitoringManager mm = new MonitoringManagerImpl();
-        mm.addMonitoringOperation(deviceList);
+        MonitoringManager manager = new MonitoringManagerImpl();
+        manager.addMonitoringOperation(deviceList);
 
         policyManagerService.checkCompliance(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), complianceFeatures);
         boolean deviceCompliance = policyManagerService.isCompliant(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A));
@@ -284,9 +284,9 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
         List<Device> deviceList = new ArrayList<>();
         deviceList.add(device);
 
-        MonitoringManager mm = new MonitoringManagerImpl();
-        mm.addMonitoringOperation(deviceList);
-        
+        MonitoringManager manager = new MonitoringManagerImpl();
+        manager.addMonitoringOperation(deviceList);
+
         policyManagerService.checkCompliance(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), complianceFeatures);
         boolean deviceCompliance = policyManagerService.isCompliant(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A));
         Assert.assertFalse(deviceCompliance, "Policy was compliant even though the response was not compliant");

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
@@ -279,7 +279,6 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
         complianceFeature.setCompliance(false);
         complianceFeatures.add(complianceFeature);
 
-
         Device device = DeviceManagementDataHolder.getInstance().getDeviceManagementProvider().
                 getDevice(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), false);
         List<Device> deviceList = new ArrayList<>();
@@ -287,8 +286,7 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
 
         MonitoringManager mm = new MonitoringManagerImpl();
         mm.addMonitoringOperation(deviceList);
-
-
+        
         policyManagerService.checkCompliance(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), complianceFeatures);
         boolean deviceCompliance = policyManagerService.isCompliant(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A));
         Assert.assertFalse(deviceCompliance, "Policy was compliant even though the response was not compliant");

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
@@ -46,6 +46,8 @@ import org.wso2.carbon.policy.mgt.common.PolicyEvaluationPoint;
 import org.wso2.carbon.policy.mgt.common.PolicyManagementException;
 import org.wso2.carbon.policy.mgt.core.enforcement.DelegationTask;
 import org.wso2.carbon.policy.mgt.core.internal.PolicyManagementDataHolder;
+import org.wso2.carbon.policy.mgt.core.mgt.MonitoringManager;
+import org.wso2.carbon.policy.mgt.core.mgt.impl.MonitoringManagerImpl;
 import org.wso2.carbon.policy.mgt.core.mock.TypeXDeviceManagementService;
 import org.wso2.carbon.policy.mgt.core.task.MonitoringTask;
 import org.wso2.carbon.policy.mgt.core.task.TaskScheduleService;
@@ -232,7 +234,7 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
     }
 
     @Test(dependsOnMethods = "applyPolicy")
-    public void checkCompliance() throws PolicyComplianceException {
+    public void checkCompliance() throws PolicyComplianceException, DeviceManagementException {
         new MonitoringTask().execute();
 
         List<ComplianceFeature> complianceFeatures = new ArrayList<>();
@@ -246,6 +248,15 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
         complianceFeature.setMessage("Test message");
         complianceFeature.setCompliance(true);
         complianceFeatures.add(complianceFeature);
+
+        Device device = DeviceManagementDataHolder.getInstance().getDeviceManagementProvider().
+                getDevice(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), false);
+        List<Device> deviceList = new ArrayList<>();
+        deviceList.add(device);
+
+        MonitoringManager mm = new MonitoringManagerImpl();
+        mm.addMonitoringOperation(deviceList);
+
         policyManagerService.checkCompliance(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), complianceFeatures);
         boolean deviceCompliance = policyManagerService.isCompliant(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A));
 
@@ -253,7 +264,7 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
     }
 
     @Test(dependsOnMethods = "checkCompliance")
-    public void checkNonCompliance() throws PolicyComplianceException {
+    public void checkNonCompliance() throws PolicyComplianceException, DeviceManagementException {
         new MonitoringTask().execute();
 
         List<ComplianceFeature> complianceFeatures = new ArrayList<>();
@@ -267,6 +278,17 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
         complianceFeature.setMessage("Test message");
         complianceFeature.setCompliance(false);
         complianceFeatures.add(complianceFeature);
+
+
+        Device device = DeviceManagementDataHolder.getInstance().getDeviceManagementProvider().
+                getDevice(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), false);
+        List<Device> deviceList = new ArrayList<>();
+        deviceList.add(device);
+
+        MonitoringManager mm = new MonitoringManagerImpl();
+        mm.addMonitoringOperation(deviceList);
+
+
         policyManagerService.checkCompliance(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A), complianceFeatures);
         boolean deviceCompliance = policyManagerService.isCompliant(new DeviceIdentifier(DEVICE1, DEVICE_TYPE_A));
         Assert.assertFalse(deviceCompliance, "Policy was compliant even though the response was not compliant");

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mock/TypeXDeviceManagementService.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mock/TypeXDeviceManagementService.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.device.mgt.common.MonitoringOperation;
 import org.wso2.carbon.device.mgt.common.OperationMonitoringTaskConfig;
 import org.wso2.carbon.device.mgt.common.ProvisioningConfig;
 import org.wso2.carbon.device.mgt.common.app.mgt.ApplicationManager;
+import org.wso2.carbon.device.mgt.common.general.GeneralConfig;
 import org.wso2.carbon.device.mgt.common.policy.mgt.PolicyMonitoringManager;
 import org.wso2.carbon.device.mgt.common.pull.notification.PullNotificationSubscriber;
 import org.wso2.carbon.device.mgt.common.push.notification.PushNotificationConfig;
@@ -94,6 +95,11 @@ public class TypeXDeviceManagementService implements DeviceManagementService {
 
     @Override
     public DeviceStatusTaskPluginConfig getDeviceStatusTaskPluginConfig() {
+        return null;
+    }
+
+    @Override
+    public GeneralConfig getGeneralConfig() {
         return null;
     }
 }


### PR DESCRIPTION
## Purpose
This fixes the issue where policy monitoring is configured per device type, they were not used. With this fix, main policy monitoring config is with cdm-config.xml and per device type can be enabled separately in the device type related xml file.

## Goals
Taking <PolicyMonitoring enabled="true"/> values to enable policy monitoring for each device type

## Approach
NA

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
Added

## Security checks
YES

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
NA
 
## Learning
NA