### PR TITLE
Removing DOM ID duplication in geo dashboard unit

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/geo-dashboard.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/geo-dashboard.hbs
@@ -576,8 +576,8 @@
         <div id="setWithinAlert">
             <form role="form" style="width: auto;">
                 <div class="form-group">
-                    <label class="text-primary" for="areaName">Fence name</label>
-                    <input class="form-control" id="areaName" placeholder="Fence name" type="text">
+                    <label class="text-primary" for="withinAlertAreaName">Fence name</label>
+                    <input class="form-control" id="withinAlertAreaName" placeholder="Fence name" type="text">
                     <span class="help-block">Name of the selected area(e.g. colombo)</span>
                 </div>
                 <div>
@@ -589,9 +589,8 @@
                             </button>
                         </div>
                         <div class="btn-group">
-                            <button id="editGeoJson"
-                                    onclick="$('#editWithinGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editWithinGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editWithinGeoJSON').modal('toggle')"
-                                    type="button" class="btn btn-default btn-xs">Edit
+                            <button onclick="$('#editWithinGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editWithinGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editWithinGeoJSON').modal('toggle')"
+                                    type="button" class="btn btn-default btn-xs editGeoJson">Edit
                             </button>
                         </div>
                         <div class="btn-group">
@@ -607,8 +606,8 @@
         <div id="setExitAlert">
             <form role="form" style="width: auto;">
                 <div class="form-group">
-                    <label class="text-primary" for="areaName">Fence name</label>
-                    <input class="form-control" id="areaName" placeholder="Fence name" type="text">
+                    <label class="text-primary" for="exitAlertAreaName">Fence name</label>
+                    <input class="form-control" id="exitAlertAreaName" placeholder="Fence name" type="text">
                     <span class="help-block">Name of the selected area(e.g. colombo)</span>
                 </div>
                 <div>
@@ -620,9 +619,8 @@
                             </button>
                         </div>
                         <div class="btn-group">
-                            <button id="editGeoJson"
-                                    onclick="$('#editExitGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editExitGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editExitGeoJSON').modal('toggle')"
-                                    type="button" class="btn btn-default btn-xs">Edit
+                            <button onclick="$('#editExitGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editExitGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editExitGeoJSON').modal('toggle')"
+                                    type="button" class="btn btn-default btn-xs editGeoJson">Edit
                             </button>
                         </div>
                         <div class="btn-group">
@@ -639,8 +637,8 @@
         <div id="setStationeryAlert">
             <form role="form" style="width: auto;">
                 <div class="form-group">
-                    <label class="text-primary" for="areaName">Fence name</label>
-                    <input class="form-control" id="areaName" placeholder="Stationery name" type="text">
+                    <label class="text-primary" for="stationaryAlertAreaName">Fence name</label>
+                    <input class="form-control" id="stationaryAlertAreaName" placeholder="Stationery name" type="text">
                     <span class="help-block">Name of the selected area(e.g. colombo)</span>
 
                     <label class="text-primary" for="fRadius">Fluctuation radius</label>
@@ -658,9 +656,8 @@
                             </button>
                         </div>
                         <div class="btn-group">
-                            <button id="editGeoJson"
-                                    onclick="$('#editWithinGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editWithinGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editWithinGeoJSON').modal('toggle')"
-                                    type="button" class="btn btn-default btn-xs">Edit
+                            <button onclick="$('#editWithinGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editWithinGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editWithinGeoJSON').modal('toggle')"
+                                    type="button" class="btn btn-default btn-xs editGeoJson">Edit
                             </button>
                         </div>
                         <div class="btn-group">
@@ -676,8 +673,8 @@
         <div id="setTrafficAlert">
             <form role="form" style="width: auto;">
                 <div class="form-group">
-                    <label class="text-primary" for="areaName">Fence name</label>
-                    <input class="form-control" id="areaName" placeholder="Area Name" type="text">
+                    <label class="text-primary" for="trafficAlertAreaName">Fence name</label>
+                    <input class="form-control" id="trafficAlertAreaName" placeholder="Area Name" type="text">
                     <span class="help-block">Name of the selected area(e.g. colombo)</span>
                 </div>
                 <div>
@@ -689,9 +686,8 @@
                             </button>
                         </div>
                         <div class="btn-group">
-                            <button id="editGeoJson"
-                                    onclick="$('#editTrafficGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editTrafficGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editTrafficGeoJSON').modal('toggle')"
-                                    type="button" class="btn btn-default btn-xs">Edit
+                            <button onclick="$('#editTrafficGeoJSON #updateGeoJson').attr('leaflet_id',$(this).attr('leaflet_id'));$('#editTrafficGeoJSON textarea').text(JSON.stringify(map._layers[$(this).attr('leaflet_id')].toGeoJSON(),null, '\t'));$('#editTrafficGeoJSON').modal('toggle')"
+                                    type="button" class="btn btn-default btn-xs editGeoJson">Edit
                             </button>
                         </div>
                         <div class="btn-group">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/geo-dashboard.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/geo-dashboard.js
@@ -60,6 +60,6 @@ function onRequest(context) {
     } else {
         viewModel.lastLocation = stringify({});
     }
-    viewModel.geoServicesEnabled = devicemgtProps.serverConfig.operationAnalyticsConfiguration.isEnabled;
+    viewModel.geoServicesEnabled = devicemgtProps.serverConfig.geoLocationConfiguration.isEnabled;
     return viewModel;
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_fencing.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_fencing.js
@@ -271,8 +271,8 @@ function createPopup(layer,id) {
     	return;
     }
     
-    popupTemplate.find('#exportGeoJson').attr('leaflet_id', layer._leaflet_id);
-    popupTemplate.find('#editGeoJson').attr('leaflet_id', layer._leaflet_id);
+    popupTemplate.find('.exportGeoJson').attr('leaflet_id', layer._leaflet_id);
+    popupTemplate.find('.editGeoJson').attr('leaflet_id', layer._leaflet_id);
 
     layer.bindPopup(popupTemplate.html(), {closeOnClick: false, closeButton: false}).openPopup();
     // transparent the layer .leaflet-popup-content-wrapper

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_remote.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_remote.js
@@ -233,7 +233,7 @@ function setWithinAlert(leafletId) {
      * (look in get_alerts for .replace() method)
      * */
     var selectedAreaGeoJson = JSON.stringify(map._layers[leafletId].toGeoJSON().geometry).replace(/"/g, "'");
-    var areaName = $("#areaName").val();
+    var areaName = $("#withinAlertAreaName").val();
     var queryName = areaName;
 
 
@@ -292,7 +292,7 @@ function setExitAlert(leafletId) {
      * (look in get_alerts for .replace() method)
      * */
     var selectedAreaGeoJson = JSON.stringify(map._layers[leafletId].toGeoJSON().geometry).replace(/"/g, "'");
-    var areaName = $("#areaName").val();
+    var areaName = $("#exitAlertAreaName").val();
     var queryName = areaName;
 
 
@@ -357,7 +357,7 @@ function setStationeryAlert(leafletId) {
 
     var selectedProcessedAreaGeoJson = JSON.stringify(selectedAreaGeoJson).replace(/"/g, "'");
 
-    var stationeryName = $("#areaName").val();
+    var stationeryName = $("#stationaryAlertAreaName").val();
     var queryName = stationeryName;
     var fluctuationRadius = $("#fRadius").val();
     var time = $("#time").val();
@@ -477,7 +477,7 @@ function setTrafficAlert(leafletId) {
 
     var selectedProcessedAreaGeoJson = JSON.stringify(selectedAreaGeoJson).replace(/"/g, "'");
 
-    var areaName = $("#areaName").val();
+    var areaName = $("#trafficAlertAreaName").val();
     var queryName = areaName;
     //var time = $("#time").val();
 


### PR DESCRIPTION
## Purpose
> When geo location services is `enabled` and navigated into the device overview page browser duplicate DOM ID errors thrown in browser console. Further; two instances of geo-maps loaded in the same page. This PR resolves https://github.com/wso2/product-iots/issues/1623.

## Goals
> Removing DOM ID duplication in geo dashboard unit

## Approach
> DOM IDs renamed to avoid duplication

## User stories
> N/A

## Release note
> Removing DOM ID duplication in geo dashboard unit

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-device-mgt-plugins/pull/873

## Migrations (if applicable)
> N/A

## Test environment
> Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_141, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_141.jdk/Contents/Home/jre
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.2", arch: "x86_64", family: "mac"
 
## Learning
> N/A