### PR TITLE
Fixed https://github.com/wso2/product-iots/issues/1564

### DIFF
--- a/features/device-mgt/org.wso2.carbon.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
+++ b/features/device-mgt/org.wso2.carbon.device.mgt.basics.feature/src/main/resources/conf/cdm-config.xml
@@ -140,7 +140,7 @@
     <!--This configuration used to configure the options for remote device control feature -->
     <RemoteSessionConfiguration>
         <Enabled>true</Enabled>
-        <RemoteSessionServerUrl>wss://localhost:9443</RemoteSessionServerUrl>
+        <RemoteSessionServerUrl>ws://localhost:9763</RemoteSessionServerUrl>
         <MaximumHTTPConnectionPerHost>2</MaximumHTTPConnectionPerHost>
         <MaximumTotalHTTPConnections>100</MaximumTotalHTTPConnections>
         <MaximumMessagesPerSecond>20</MaximumMessagesPerSecond>


### PR DESCRIPTION
## Purpose
> Fix for issue https://github.com/wso2/product-iots/issues/1564

## Goals
> Allow to use remote control feature OOB

## Approach
> Fall down to ws instead of wss, with OOB. wss can be configured by adding valid ssl certificate to the server.

## User stories
> N/A

## Release note
> Fixed issue in not connecting to remote device with OOB IoTS.

## Documentation
> TBD with feature documentation

## Training
> N/A

## Certification
> N/A, bug fix

## Marketing
> N/A

## Automation tests
> N/A, config change, can't automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-device-mgt/pull/1122

## Migrations (if applicable)
> N/A

## Test environment
- OS - Fedora 23 x64
- Browser - Chrome and Firefox
- DB - H2

## Learning
> N/A