### PR TITLE
Adding notification for the user on a Websocket handshake failure

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.default.device.type.realtime.analytics-view/analytics-view.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.default.device.type.realtime.analytics-view/analytics-view.hbs
@@ -37,6 +37,9 @@
         <i class="fw fw-statistics fw-stack-1x"></i>
     </span> View Device Analytics
 </a>
+<div class="hide" id="websocker-onerror">
+    Realtime Analytics is not available. Failed to connect to the websocket. Please make sure; '<a style="color: white" href="$webSocketURL">$webSocketURL</a>' is available and re-try again.
+</div>
 <!-- /statistics -->
 {{#zone "bottomJs"}}
     {{js "js/moment.min.js"}}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.default.device.type.realtime.analytics-view/public/js/device-stats.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.default.device.type.realtime.analytics-view/public/js/device-stats.js
@@ -48,6 +48,15 @@ function connect(target) {
 			}
 			$("#time-mode").text("Real Time Mode");
         };
+        ws.onerror = function (webSocketData) {
+            var websocketURL = webSocketData.currentTarget.url;
+            websocketURL = websocketURL.replace("wss://","https://");
+            var uriParts = websocketURL.split("/");
+            websocketURL = uriParts[0] + "//" + uriParts[2];
+            var errorMsg = $("#websocker-onerror").html();
+            errorMsg = errorMsg.replace(new RegExp('\\$webSocketURL', 'g'), websocketURL);
+            $("#div-chart").html("<div class='alert alert-danger'>" + errorMsg + "</div>");
+        };
     }
 }
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/websocket.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/websocket.js
@@ -571,7 +571,11 @@ var webSocketOnAlertClose = function (e) {
 };
 
 var webSocketOnAlertError = function (e) {
-    noty({text: 'Something went wrong when trying to connect to <b>' + alertWebSocketURL + '<b/>', type: 'error'});
+    var wsURL = alertWebSocketURL;
+    wsURL = wsURL.replace("wss://","https://");
+    var uriParts = wsURL.split("/");
+    wsURL = uriParts[0] + "//" + uriParts[2];
+    noty({text: 'Something went wrong when trying to connect to <b>' + wsURL + '<b/>', type: 'error'});
 };
 
 var webSocketSpatialOnOpen = function () {
@@ -598,7 +602,11 @@ var webSocketSpatialOnClose = function (e) {
 };
 
 var webSocketSpatialOnError = function (err) {
-    noty({text: 'Something went wrong when trying to connect to <b>' + webSocketURL + '<b/>', type: 'error'});
+    var wsURL = webSocketURL;
+    wsURL = wsURL.replace("wss://","https://");
+    var uriParts = wsURL.split("/");
+    wsURL = uriParts[0] + "//" + uriParts[2];
+    noty({text: 'Something went wrong when trying to connect to <b>' + wsURL + '<b/>', type: 'error'});
 };
 
 


### PR DESCRIPTION
## Purpose
> On the device's realtime analytics page; unless specified and exempted websocket URL endpoint for the IoT Analytics Server will be failed without notifying the user. This PR resolves https://github.com/wso2/product-iots/issues/1659.

## Goals
> Adding notification for the user on a Websocket handshake failure

## Approach
> N/A

## User stories
> N/A

## Release note
> Adding notification for the user on a Websocket handshake failure

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/carbon-device-mgt-plugins/pull/884, https://github.com/wso2/product-iots/pull/1660

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A