### PR TITLE
Fixed https://github.com/wso2/product-iots/issues/1671

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/OperationManagementNegativeDBOperationTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/OperationManagementNegativeDBOperationTest.java
@@ -17,6 +17,7 @@
 */
 package org.wso2.carbon.device.mgt.core.operation;
 
+import org.powermock.api.mockito.PowerMockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -28,7 +29,7 @@ import org.wso2.carbon.device.mgt.common.PaginationRequest;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManagementException;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
-import org.wso2.carbon.device.mgt.common.push.notification.NotificationStrategy;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.TestDeviceManagementService;
 import org.wso2.carbon.device.mgt.core.common.BaseDeviceManagementTest;
 import org.wso2.carbon.device.mgt.core.common.TestDataHolder;
@@ -39,10 +40,10 @@ import org.wso2.carbon.device.mgt.core.operation.mgt.dao.OperationManagementDAOF
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 
 /**
  * Negative test cases for {@link OperationManagerImpl}
@@ -83,8 +84,11 @@ public class OperationManagementNegativeDBOperationTest extends BaseDeviceManage
                 throw new Exception("Incorrect device with ID - " + device.getDeviceIdentifier() + " returned!");
             }
         }
-        NotificationStrategy notificationStrategy = new TestNotificationStrategy();
-        this.operationMgtService = new OperationManagerImpl(DEVICE_TYPE, notificationStrategy);
+        DeviceManagementService deviceManagementService
+                = new TestDeviceManagementService(DEVICE_TYPE, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        this.operationMgtService = PowerMockito.spy(new OperationManagerImpl(DEVICE_TYPE, deviceManagementService));
+        PowerMockito.when(this.operationMgtService, "getNotificationStrategy")
+                .thenReturn(new TestNotificationStrategy());
         this.setMockDataSource();
     }
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/OperationManagementNoDBSchemaTests.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/OperationManagementNoDBSchemaTests.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.device.mgt.core.operation;
 
+import org.powermock.api.mockito.PowerMockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import org.wso2.carbon.device.mgt.common.PaginationRequest;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManagementException;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
-import org.wso2.carbon.device.mgt.common.push.notification.NotificationStrategy;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.DeviceManagementConstants;
 import org.wso2.carbon.device.mgt.core.TestDeviceManagementService;
 import org.wso2.carbon.device.mgt.core.common.BaseDeviceManagementTest;
@@ -42,9 +43,9 @@ import org.wso2.carbon.device.mgt.core.operation.mgt.dao.OperationManagementDAOF
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
+import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.List;
-import javax.sql.DataSource;
 
 /**
  * This is the testcase which covers the methods from {@link OperationManager}
@@ -82,8 +83,11 @@ public class OperationManagementNoDBSchemaTests extends BaseDeviceManagementTest
                 throw new Exception("Incorrect device with ID - " + device.getDeviceIdentifier() + " returned!");
             }
         }
-        NotificationStrategy notificationStrategy = new TestNotificationStrategy();
-        this.operationMgtService = new OperationManagerImpl(DEVICE_TYPE, notificationStrategy);
+        DeviceManagementService deviceManagementService
+                = new TestDeviceManagementService(DEVICE_TYPE, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        this.operationMgtService = PowerMockito.spy(new OperationManagerImpl(DEVICE_TYPE, deviceManagementService));
+        PowerMockito.when(this.operationMgtService, "getNotificationStrategy")
+                .thenReturn(new TestNotificationStrategy());
     }
 
     @Test(description = "add operation", expectedExceptions = OperationManagementException.class)

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/ScheduledTaskOperationTests.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/ScheduledTaskOperationTests.java
@@ -18,6 +18,7 @@
 package org.wso2.carbon.device.mgt.core.operation;
 
 import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -29,6 +30,7 @@ import org.wso2.carbon.device.mgt.common.operation.mgt.Activity;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManagementException;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.TestDeviceManagementService;
 import org.wso2.carbon.device.mgt.core.TestTaskServiceImpl;
 import org.wso2.carbon.device.mgt.core.common.BaseDeviceManagementTest;
@@ -87,8 +89,11 @@ public class ScheduledTaskOperationTests extends BaseDeviceManagementTest {
             }
         }
         DeviceConfigurationManager.getInstance().initConfig(CDM_CONFIG_LOCATION);
-        TestNotificationStrategy notificationStrategy = new TestNotificationStrategy();
-        this.operationMgtService = new OperationManagerImpl(DEVICE_TYPE, notificationStrategy);
+        DeviceManagementService deviceManagementService
+                = new TestDeviceManagementService(DEVICE_TYPE, MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+        this.operationMgtService = PowerMockito.spy(new OperationManagerImpl(DEVICE_TYPE, deviceManagementService));
+        PowerMockito.when(this.operationMgtService, "getNotificationStrategy")
+                .thenReturn(new TestNotificationStrategy());
     }
 
 

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/PolicyManagerServiceImplTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.device.mgt.common.policy.mgt.ProfileFeature;
 import org.wso2.carbon.device.mgt.common.policy.mgt.monitor.ComplianceFeature;
 import org.wso2.carbon.device.mgt.common.policy.mgt.monitor.NonComplianceData;
 import org.wso2.carbon.device.mgt.common.policy.mgt.monitor.PolicyComplianceException;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.internal.DeviceManagementDataHolder;
 import org.wso2.carbon.device.mgt.core.operation.mgt.OperationManagerImpl;
 import org.wso2.carbon.device.mgt.core.operation.mgt.PolicyOperation;
@@ -86,9 +87,9 @@ public class  PolicyManagerServiceImplTest extends BasePolicyManagementDAOTest {
     public void addPolicy() throws DeviceManagementException, GroupManagementException, PolicyManagementException {
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         policyManagerService = new PolicyManagerServiceImpl();
-
-        deviceMgtService.registerDeviceType(new TypeXDeviceManagementService(DEVICE_TYPE_A));
-        operationManager = new OperationManagerImpl(DEVICE_TYPE_A);
+        DeviceManagementService deviceManagementService = new TypeXDeviceManagementService(DEVICE_TYPE_A);
+        deviceMgtService.registerDeviceType(deviceManagementService);
+        operationManager = new OperationManagerImpl(DEVICE_TYPE_A, deviceManagementService);
         enrollDevice(DEVICE1, DEVICE_TYPE_A);
         createDeviceGroup(GROUP1);
         DeviceGroup group1 = groupMgtService.getGroup(GROUP1);

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mgt/impl/FeatureManagerImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mgt/impl/FeatureManagerImplTest.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.device.mgt.common.group.mgt.DeviceGroup;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
 import org.wso2.carbon.device.mgt.common.policy.mgt.Profile;
 import org.wso2.carbon.device.mgt.common.policy.mgt.ProfileFeature;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.operation.mgt.OperationManagerImpl;
 import org.wso2.carbon.policy.mgt.common.FeatureManagementException;
 import org.wso2.carbon.policy.mgt.core.BasePolicyManagementDAOTest;
@@ -77,9 +78,9 @@ public class FeatureManagerImplTest extends BasePolicyManagementDAOTest {
         super.initializeServices();
 
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
-
-        deviceMgtService.registerDeviceType(new TypeXDeviceManagementService(DEVICE_TYPE_D));
-        operationManager = new OperationManagerImpl(DEVICE_TYPE_D);
+        DeviceManagementService deviceManagementService = new TypeXDeviceManagementService(DEVICE_TYPE_D);
+        deviceMgtService.registerDeviceType(deviceManagementService);
+        operationManager = new OperationManagerImpl(DEVICE_TYPE_D, deviceManagementService);
         featureManager = new FeatureManagerImpl();
 
         enrollDevice(DEVICE4, DEVICE_TYPE_D);

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mgt/impl/MonitoringManagerImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mgt/impl/MonitoringManagerImplTest.java
@@ -22,6 +22,7 @@ import org.wso2.carbon.device.mgt.common.policy.mgt.Profile;
 import org.wso2.carbon.device.mgt.common.policy.mgt.ProfileFeature;
 import org.wso2.carbon.device.mgt.common.policy.mgt.monitor.ComplianceFeature;
 import org.wso2.carbon.device.mgt.common.policy.mgt.monitor.PolicyComplianceException;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.operation.mgt.OperationManagerImpl;
 import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.policy.mgt.core.BasePolicyManagementDAOTest;
@@ -83,8 +84,9 @@ public class MonitoringManagerImplTest extends BasePolicyManagementDAOTest{
 
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
 
-        deviceMgtService.registerDeviceType(new TypeXDeviceManagementService(DEVICE_TYPE_E));
-        operationManager = new OperationManagerImpl(DEVICE_TYPE_E);
+        DeviceManagementService deviceManagementService = new TypeXDeviceManagementService(DEVICE_TYPE_E);
+        deviceMgtService.registerDeviceType(deviceManagementService);
+        operationManager = new OperationManagerImpl(DEVICE_TYPE_E, deviceManagementService);
         featureManager = new FeatureManagerImpl();
         monitoringManager = new MonitoringManagerImpl();
         policyManager = new PolicyManagerImpl();

--- a/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mgt/impl/ProfileManagerImplTest.java
+++ b/components/policy-mgt/org.wso2.carbon.policy.mgt.core/src/test/java/org/wso2/carbon/policy/mgt/core/mgt/impl/ProfileManagerImplTest.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.device.mgt.common.group.mgt.DeviceGroup;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
 import org.wso2.carbon.device.mgt.common.policy.mgt.Profile;
 import org.wso2.carbon.device.mgt.common.policy.mgt.ProfileFeature;
+import org.wso2.carbon.device.mgt.common.spi.DeviceManagementService;
 import org.wso2.carbon.device.mgt.core.operation.mgt.OperationManagerImpl;
 import org.wso2.carbon.policy.mgt.common.ProfileManagementException;
 import org.wso2.carbon.policy.mgt.core.BasePolicyManagementDAOTest;
@@ -71,8 +72,9 @@ public class ProfileManagerImplTest extends BasePolicyManagementDAOTest {
     public void initialize() throws Exception {
         log.info("Initializing policy manager tests");
         super.initializeServices();
-        deviceMgtService.registerDeviceType(new TypeXDeviceManagementService(DEVICE_TYPE_C));
-        operationManager = new OperationManagerImpl(DEVICE_TYPE_C);
+        DeviceManagementService deviceManagementService = new TypeXDeviceManagementService(DEVICE_TYPE_C);
+        deviceMgtService.registerDeviceType(deviceManagementService);
+        operationManager = new OperationManagerImpl(DEVICE_TYPE_C, deviceManagementService);
         enrollDevice(DEVICE3, DEVICE_TYPE_C);
         createDeviceGroup(GROUP3);
         DeviceGroup group1 = groupMgtService.getGroup(GROUP3);


### PR DESCRIPTION
## Purpose
> As a result of FCM API key is getting cached, once we change the FCM API key while running the server, it is required to restart the server. This fix avoids the server restarting when we change the FCM API key.
Fixed https://github.com/wso2/product-iots/issues/1671

## Goals
> Get PushNotificationProvider dynamically based on the platform configurations

## Approach
> Update operation manager to get current platform configurations from registry on demand with a internal cache.

## User stories
> N/A, Bug fix

## Release note
> Fixed https://github.com/wso2/product-iots/issues/1671

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> N/A, Bug fix

## Certification
> N/A, Bug fix

## Marketing
> N/A, Bug fix

## Automation tests
 - Unit tests 
   > Code coverage 85%
 - Integration tests
   > Covered with existing tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A, Bug fix

## Related PRs
> https://github.com/wso2/carbon-device-mgt-plugins/pull/887

## Migrations (if applicable)
> N/A, Bug fix

## Test environment
> Fedora 23 Linux 4.8.13-100.fc23.x86_64, Oracle JDK 1.8.0_91-b14, H2
 
## Learning
> N/A, Bug fix