### PR TITLE
Fixing policy view interface not loading issue

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.effective-policy.view/public/js/view.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.effective-policy.view/public/js/view.js
@@ -27,19 +27,19 @@ var displayPolicy = function (policyPayloadObj) {
     $("#policy-action").text(policyPayloadObj.compliance.toUpperCase());
     $("#policy-description").text(policyPayloadObj["description"]);
     var policyStatus = "Active";
-    if (policyPayloadObj["active"] == true && policyPayloadObj["updated"] == true) {
+    if (policyPayloadObj["active"] === true && policyPayloadObj["updated"] === true) {
         policyStatus = '<i class="fw fw-warning icon-success"></i> Active/Updated</span>';
-    } else if (policyPayloadObj["active"] == true && policyPayloadObj["updated"] == false) {
+    } else if (policyPayloadObj["active"] === true && policyPayloadObj["updated"] === false) {
         policyStatus = '<i class="fw fw-success icon-success"></i> Active</span>';
-    } else if (policyPayloadObj["active"] == false && policyPayloadObj["updated"] == true) {
+    } else if (policyPayloadObj["active"] === false && policyPayloadObj["updated"] === true) {
         policyStatus = '<i class="fw fw-warning icon-warning"></i> Inactive/Updated</span>';
-    } else if (policyPayloadObj["active"] == false && policyPayloadObj["updated"] == false) {
+    } else if (policyPayloadObj["active"] === false && policyPayloadObj["updated"] === false) {
         policyStatus = '<i class="fw fw-error icon-danger"></i> Inactive</span>';
     }
 
     $("#policy-status").html(policyStatus);
 
-    if (policyPayloadObj.users == null) {
+    if (!policyPayloadObj.users) {
         $("#policy-users").text("NONE");
     }
     else if (policyPayloadObj.users.length > 0) {
@@ -48,10 +48,9 @@ var displayPolicy = function (policyPayloadObj) {
         $("#users-row").addClass("hidden");
     }
 
-    if (policyPayloadObj.deviceGroups == null) {
+    if (!policyPayloadObj.deviceGroups) {
         $("#policy-groups").text("NONE");
     } else if (policyPayloadObj.deviceGroups.length > 0) {
-        debugger;
         var deviceGroups = policyPayloadObj.deviceGroups;
         var assignedGroups = [];
         for (var index in deviceGroups) {
@@ -64,7 +63,7 @@ var displayPolicy = function (policyPayloadObj) {
         $("#policy-groups").text("NONE");
     }
 
-    if (policyPayloadObj.roles == null) {
+    if (!policyPayloadObj.roles) {
         $("#policy-roles").text("NONE");
     }
     else if (policyPayloadObj.roles.length > 0) {
@@ -131,7 +130,7 @@ $(document).ready(function () {
         "/api/device-mgt/v1.0" + "/policies/effective-policy/" + getParameterByName("type") + "/" + getParameterByName("id"),
         // on success
         function (data, textStatus, jqXHR) {
-            if (jqXHR.status == 200 && data) {
+            if (jqXHR.status === 200 && data) {
                 policyPayloadObj = JSON.parse(data);
                 displayPolicy(policyPayloadObj);
             }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.edit/public/js/policy-edit.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.edit/public/js/policy-edit.js
@@ -283,7 +283,7 @@ stepForwardFrom["policy-criteria"] = function () {
  */
 var inputIsValidAgainstLength = function (input, minLength, maxLength) {
     var length = input.length;
-    return (length == minLength || (length > minLength && length < maxLength) || length == maxLength);
+    return (length === minLength || (length > minLength && length < maxLength) || length === maxLength);
 };
 
 /**
@@ -298,10 +298,10 @@ validateStep["policy-criteria"] = function () {
 
     $("input[type='radio'].select-users-radio").each(function () {
         if ($(this).is(":checked")) {
-            if ($(this).attr("id") == "users-radio-btn") {
+            if ($(this).attr("id") === "users-radio-btn") {
                 selectedAssignees = $("#users-input").val();
                 selectedField = "User(s)";
-            } else if ($(this).attr("id") == "user-roles-radio-btn") {
+            } else if ($(this).attr("id") === "user-roles-radio-btn") {
                 selectedAssignees = $("#user-roles-input").val();
             }
             return false;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.view/public/js/view.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.view/public/js/view.js
@@ -29,13 +29,13 @@ var displayPolicy = function (policyPayloadObj) {
     $("#policy-action").text(policyPayloadObj.compliance.toUpperCase());
     $("#policy-description").text(policyPayloadObj["description"]);
     var policyStatus = "Active";
-    if (policyPayloadObj["active"] == true && policyPayloadObj["updated"] == true) {
+    if (policyPayloadObj["active"] === true && policyPayloadObj["updated"] === true) {
         policyStatus = '<i class="fw fw-warning icon-success"></i> Active/Updated</span>';
-    } else if (policyPayloadObj["active"] == true && policyPayloadObj["updated"] == false) {
+    } else if (policyPayloadObj["active"] === true && policyPayloadObj["updated"] === false) {
         policyStatus = '<i class="fw fw-success icon-success"></i> Active</span>';
-    } else if (policyPayloadObj["active"] == false && policyPayloadObj["updated"] == true) {
+    } else if (policyPayloadObj["active"] === false && policyPayloadObj["updated"] === true) {
         policyStatus = '<i class="fw fw-warning icon-warning"></i> Inactive/Updated</span>';
-    } else if (policyPayloadObj["active"] == false && policyPayloadObj["updated"] == false) {
+    } else if (policyPayloadObj["active"] === false && policyPayloadObj["updated"] === false) {
         policyStatus = '<i class="fw fw-error icon-danger"></i> Inactive</span>';
     }
 
@@ -47,7 +47,6 @@ var displayPolicy = function (policyPayloadObj) {
         $("#users-row").addClass("hidden");
     }
     if (policyPayloadObj.deviceGroups.length > 0) {
-        debugger;
         var deviceGroups = policyPayloadObj.deviceGroups;
         var assignedGroups = [];
         for (var index in deviceGroups) {


### PR DESCRIPTION
## Purpose
> When a policy is created and viewed the policy using the policy view icon the page keeps loading sometimes due to an undefined deviceGroups variable inside the policyPayloadObj. The purpose of this PR is to fix this issue.
Resolves wso2/product-iots#1681

## Goals
> Fixing the above issue

## Approach
> This commit fixes this issue by improving the code where the null check has been made to check if the deviceGroup is null. Also made few improvements in the code where the checks have been made.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A, This is a bug fix.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Ubuntu 16.04, JDK 1.8.0_161,H2
 
## Learning
> N/A