### PR TITLE
Fixing issue of devices listing page filters are not showing all the available filtering options

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/api/data-tables-invoker-api.jag
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/api/data-tables-invoker-api.jag
@@ -25,6 +25,11 @@ var uriMatcher = new URIMatcher(String(uri));
 var devicemgtProps = require("/app/modules/conf-reader/main.js")["conf"];
 var serviceInvokers = require("/app/modules/oauth/token-protected-service-invokers.js")["invokers"];
 var utility = require("/app/modules/utility.js")["utility"];
+var deviceModule = require("/app/modules/business-controllers/device.js")["deviceModule"];
+var EnrolmentInfo = Packages.org.wso2.carbon.device.mgt.common.EnrolmentInfo;
+
+var DTYPE_CONF_DEVICE_TYPE_KEY = "deviceType";
+var DTYPE_CONF_DEVICE_TYPE_LABEL_KEY = "label";
 
 function appendQueryParam (url, queryParam , value) {
     if (url.indexOf("?") > 0) {
@@ -33,7 +38,45 @@ function appendQueryParam (url, queryParam , value) {
     return url + "?" + queryParam + "=" + value;
 }
 
-if (uriMatcher.match("/{context}/api/data-tables/invoker")) {
+if (uriMatcher.match("/{context}/api/data-tables/invoker/filters")) {
+    var result = {};
+    var i;
+    //Fetching Status types
+    var status = EnrolmentInfo.Status.values();
+    var statusArr = [];
+    for(i = 0; i < status.length; i++){
+        statusArr.push(status[i].name());
+    }
+    result.status = statusArr;
+    //Fetching Ownership types
+    var ownership = EnrolmentInfo.OwnerShip.values();
+    var ownershipArr = [];
+    for(i = 0; i < ownership.length; i++){
+        ownershipArr.push(ownership[i].name());
+    }
+    result.ownership = ownershipArr;
+    //Fetching Device Types
+    result.deviceTypes = [];
+    var deviceTypesRes = deviceModule.getDeviceTypes();
+    if (deviceTypesRes.status === "success") {
+        var deviceTypes = deviceTypesRes["content"]["deviceTypes"];
+        for (i = 0; i < deviceTypes.length; i++) {
+            var deviceTypeLabel = deviceTypes[i];
+            var configs = utility.getDeviceTypeConfig(deviceTypeLabel);
+            if (configs) {
+                if (configs[DTYPE_CONF_DEVICE_TYPE_KEY][DTYPE_CONF_DEVICE_TYPE_LABEL_KEY]) {
+                    deviceTypeLabel = configs[DTYPE_CONF_DEVICE_TYPE_KEY][DTYPE_CONF_DEVICE_TYPE_LABEL_KEY];
+                }
+            }
+            result.deviceTypes.push(deviceTypeLabel);
+        }
+    }
+    //Adding policy compliance
+    result.compliance = ["MONITOR", "ENFORCE", "WARN", "BLOCK"];
+    response["status"] = 200;
+    response["content"] =  result;
+    response["contentType"] = "application/json";
+} else if (uriMatcher.match("/{context}/api/data-tables/invoker")) {
     var url = request.getParameter("url");
     var targetURL = devicemgtProps["httpsURL"] + request.getParameter("url");
     //noinspection JSUnresolvedFunction getAllParameters

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/modules/business-controllers/policy.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/modules/business-controllers/policy.js
@@ -51,7 +51,19 @@ policyModule = function () {
                     policyObjectToView["deviceTypeIcon"] = policyObjectToView["platform"];
                 }
                 //policyObjectToView["icon"] = utility.getDeviceThumb(policyObjectToView["platform"]);
-                policyObjectToView["ownershipType"] = policyObjectFromRestEndpoint["ownershipType"];
+                var ownershipType = "None";
+                var deviceGroups = policyObjectFromRestEndpoint["deviceGroups"];
+                if (deviceGroups) {
+                    for (var j = 0; j < deviceGroups.length; j++) {
+                        var deviceGroup = deviceGroups[j];
+                        if (deviceGroup.name === "COPE") {
+                            ownershipType = (ownershipType === "BYOD") ? "BYOD & COPE" : "COPE";
+                        } else if (deviceGroup.name === "BYOD") {
+                            ownershipType = (ownershipType === "COPE") ? "BYOD & COPE" : "BYOD";
+                        }
+                    }
+                }
+                policyObjectToView["ownershipType"] = ownershipType;
 
                 var assignedRoleCount = policyObjectFromRestEndpoint["roles"].length;
                 var assignedUserCount = policyObjectFromRestEndpoint["users"].length;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/devices.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/devices.hbs
@@ -160,7 +160,7 @@
                             <thead>
                             <tr class="sort-row">
                                 <th class="no-sort"></th>
-                                <th>By Device Name</th>
+                                <th class="no-sort"></th>
                                 <th>By Owner</th>
                                 <th>By Status</th>
                                 <th>By Platform</th>
@@ -169,11 +169,11 @@
                             </tr>
                             <tr class="filter-row filter-box">
                                 <th class="no-sort"></th>
-                                <th data-for="By Device name" class="text-filter"></th>
+                                <th class="no-sort"></th>
                                 <th data-for="By Owner" class="text-filter"></th>
-                                <th data-for="By Status" class="select-filter"></th>
+                                <th data-for="By Status" class="select-filter data-status"></th>
                                 <th data-for="By Platform" class="select-filter data-platform"></th>
-                                <th data-for="By Ownership" class="select-filter"></th>
+                                <th data-for="By Ownership" class="select-filter data-ownership"></th>
                                 <th class="no-sort"></th>
                             </tr>
                             <tr class="bulk-action-row hidden">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.policies/policies.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.policies/policies.hbs
@@ -130,12 +130,12 @@
             <tr class="filter-row filter-box">
                 <th class="no-sort"></th>
                 <th class="no-sort"></th>
-                <th data-for="By Platform" class="select-filter"></th>
-                <th data-for="By Ownership Type" class="select-filter"></th>
+                <th data-for="By Platform" class="select-filter data-platform"></th>
+                <th data-for="By Ownership Type" class="select-filter data-ownership"></th>
                 <th data-for="By Role" class="text-filter"></th>
                 <th data-for="By User" class="text-filter"></th>
-                <th data-for="By Compliance Type" class="select-filter"></th>
-                <th data-for="By Status" class="select-filter"></th>
+                <th data-for="By Compliance Type" class="select-filter data-compliance"></th>
+                <th data-for="By Status" class="select-filter data-status"></th>
                 <th class="no-sort"></th>
             </tr>
             <tr class="bulk-action-row hidden">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.js
@@ -56,7 +56,7 @@ $.fn.datatables_extended = function (settings) {
                 search: ''
             },
             initComplete: function () {
-
+                var cachedFilterRes;
                 this.api().columns().every(function () {
 
                     var column = this;
@@ -94,8 +94,41 @@ $.fn.datatables_extended = function (settings) {
                                 }
                             });
 
+                        if (!cachedFilterRes) {
+                            $.ajax(
+                                {
+                                    url: context + "/api/data-tables/invoker/filters",
+                                    async:false,
+                                    success: function(data) {
+                                        cachedFilterRes = data;
+                                    }
+                                }
+                            );
+                        }
+
                         $(column).each(function () {
-                            if ($(column.nodes()).attr('data-search')) {
+                            var i;
+                            if (filterColumn.eq(column.index()).hasClass('data-status')) {
+                                for(i = 0; i < cachedFilterRes.status.length; i++){
+                                    var status = cachedFilterRes.status[i];
+                                    select.append('<option value="' + status + '">' + status + '</option>')
+                                }
+                            } else if (filterColumn.eq(column.index()).hasClass('data-ownership')) {
+                                for(i = 0; i < cachedFilterRes.ownership.length; i++){
+                                    var ownership = cachedFilterRes.ownership[i];
+                                    select.append('<option value="' + ownership + '">' + ownership + '</option>')
+                                }
+                            } else if (filterColumn.eq(column.index()).hasClass('data-platform')) {
+                                for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){
+                                    var deviceTypes = cachedFilterRes.deviceTypes[i];
+                                    select.append('<option value="' + deviceTypes + '">' + deviceTypes + '</option>')
+                                }
+                            } else if (filterColumn.eq(column.index()).hasClass('data-compliance')) {
+                                for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){
+                                    var compliance = cachedFilterRes.compliance[i];
+                                    select.append('<option value="' + compliance + '">' + compliance + '</option>')
+                                }
+                            } else if ($(column.nodes()).attr('data-search')) {
                                 var values = [];
                                 column.nodes().unique().sort().each(function (d, j) {
                                     var title = $(d).attr('data-display');

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.serversidepaging.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.serversidepaging.js
@@ -117,6 +117,7 @@ $.fn.datatables_extended_serverside_paging = function (settings, url, dataFilter
                     console.warn('Warning : Dependency missing - Bootstrap Tooltip Library');
                 }
 
+                var cachedFilterRes;
                 this.api().columns().every(function () {
 
                     var column = this;
@@ -169,8 +170,41 @@ $.fn.datatables_extended_serverside_paging = function (settings, url, dataFilter
                                 }
                             });
 
+                        if(!cachedFilterRes){
+                            $.ajax(
+                                {
+                                    url: context + "/api/data-tables/invoker/filters",
+                                    async:false,
+                                    success: function(data){
+                                        cachedFilterRes = data;
+                                    }
+                                }
+                            );
+                        }
+
                         $(column).each(function () {
-                            if ($(column.nodes()).attr('data-search')) {
+                            var i;
+                            if (filterColumn.eq(column.index()).hasClass('data-status')) {
+                                for(i = 0; i < cachedFilterRes.status.length; i++){
+                                    var status = cachedFilterRes.status[i];
+                                    select.append('<option value="' + status + '">' + status + '</option>')
+                                }
+                            } else if (filterColumn.eq(column.index()).hasClass('data-ownership')) {
+                                for(i = 0; i < cachedFilterRes.ownership.length; i++){
+                                    var ownership = cachedFilterRes.ownership[i];
+                                    select.append('<option value="' + ownership + '">' + ownership + '</option>')
+                                }
+                            } else if (filterColumn.eq(column.index()).hasClass('data-platform')) {
+                                for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){
+                                    var deviceTypes = cachedFilterRes.deviceTypes[i];
+                                    select.append('<option value="' + deviceTypes + '">' + deviceTypes + '</option>')
+                                }
+                            } else if (filterColumn.eq(column.index()).hasClass('data-compliance')) {
+                                for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){
+                                    var compliance = cachedFilterRes.compliance[i];
+                                    select.append('<option value="' + compliance + '">' + compliance + '</option>')
+                                }
+                            } else if ($(column.nodes()).attr('data-search')) {
                                 var titles = [];
                                 column.nodes().unique().sort().each(function (d, j) {
                                     var title = $(d).attr('data-display');

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.platform.configuration/configuration.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.platform.configuration/configuration.hbs
@@ -104,6 +104,7 @@
                                                 <button id="save-general-btn" class="wr-btn">Save</button>
                                             </div>
                                         </div>
+                                        {{#if geoServicesEnabled}}
                                         <div id="general-config-heading" role="tab">
                                             <h2 class="sub-title panel-title">
                                                 Geo Analytics
@@ -116,6 +117,7 @@
                                                 </button>
                                             </div>
                                         </div>
+                                        {{/if}}
                                     </div>
                                 </div>
                             {{/unless}}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.platform.configuration/configuration.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.platform.configuration/configuration.js
@@ -18,8 +18,9 @@
 
 function onRequest(context) {
     var utility = require("/app/modules/utility.js").utility;
-    var mdmProps = require("/app/modules/conf-reader/main.js")["conf"];
     var deviceModule = require("/app/modules/business-controllers/device.js")["deviceModule"];
+    var devicemgtProps = require("/app/modules/conf-reader/main.js")["conf"];
+
     //get all device types
     var isAuthorized = false;
     if (userModule.isAuthorized("/permission/admin/device-mgt/notifications/view")) {
@@ -48,9 +49,10 @@ function onRequest(context) {
             }
         }
     }
+    var geoServicesEnabled = devicemgtProps.serverConfig.geoLocationConfiguration.isEnabled;
     return {
+        "geoServicesEnabled": geoServicesEnabled,
         "deviceTypes": deviceTypesArray,
-        "isAuthorized": isAuthorized,
-        "isCloud": mdmProps["isCloud"]
+        "isAuthorized": isAuthorized
     };
 }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.theme/public/css/custom-desktop.css
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.theme/public/css/custom-desktop.css
@@ -6152,7 +6152,7 @@ body.inverse .fade-edge:after {
 
 .table.list-table.grid-view > thead > tr > td,
 .table.list-table.grid-view > thead > tr > th {
-    display: inline-block;
+    /*display: inline-block;*/
 }
 
 .table.list-table.grid-view > thead > tr > td:not(:empty):before,
@@ -6922,7 +6922,7 @@ select > option:hover {
 }
 
 .table.list-table:not(.grid-view) {
-    margin: 0px !important;
+    margin: 6px 0px 0px 0px !important;
 }
 
 .table.list-table:not(.grid-view) > thead, .table.list-table:not(.grid-view) > tbody, .table.list-table:not(.grid-view) > tfoot {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/jaggery.conf
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/jaggery.conf
@@ -48,7 +48,7 @@
       "path": "/lib/pages.jag"
     },
     {
-      "url": "/api/data-tables/invoker",
+      "url": "/api/data-tables/*",
       "path": "/api/data-tables-invoker-api.jag"
     },
     {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/uuf-template-app/app/units/uuf.unit.theme/public/lib/theme-wso2_1.0/less/theme-wso2.less
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/uuf-template-app/app/units/uuf.unit.theme/public/lib/theme-wso2_1.0/less/theme-wso2.less
@@ -1766,7 +1766,7 @@ input[type=number].form-control {
     }
     & > thead > tr > td,
     & > thead > tr > th {
-        display: inline-block;
+        //display: inline-block;
     }
     & > thead > tr > td:not(:empty):before,
     & > thead > tr > th:not(:empty):before {


### PR DESCRIPTION
## Purpose
> When several devices enrolled into WSO2 IoT Server; filtering options available in devices listing page does not have all the available filtering options. For instance; if you have an Inactive device in the second page of the devices listing but no inactive devices in the first page; you won't get "INACTIVE" state in the filtering by status option box.This PR Resolves https://github.com/wso2-support/carbon-device-mgt/pull/35

## Goals
> Filters are not showing all the available filtering options

## Approach
> Introduce a new jag API to the existing jaggery file, datatable-invoker.jag; to retrieve avaialble filtering options such as device types, ownership, status ...etc

## User stories
> N/A

## Release note
> Fixing issue of devices listing page filters are not showing all the available filtering options

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A