### PR TITLE
Fixing issue of the platform filter in devices listing page

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/api/data-tables-invoker-api.jag
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/api/data-tables-invoker-api.jag
@@ -61,14 +61,15 @@ if (uriMatcher.match("/{context}/api/data-tables/invoker/filters")) {
     if (deviceTypesRes.status === "success") {
         var deviceTypes = deviceTypesRes["content"]["deviceTypes"];
         for (i = 0; i < deviceTypes.length; i++) {
-            var deviceTypeLabel = deviceTypes[i];
+            var deviceTypeName = deviceTypes[i];
+            var deviceTypeLabel = deviceTypeName;
             var configs = utility.getDeviceTypeConfig(deviceTypeLabel);
             if (configs) {
                 if (configs[DTYPE_CONF_DEVICE_TYPE_KEY][DTYPE_CONF_DEVICE_TYPE_LABEL_KEY]) {
                     deviceTypeLabel = configs[DTYPE_CONF_DEVICE_TYPE_KEY][DTYPE_CONF_DEVICE_TYPE_LABEL_KEY];
                 }
             }
-            result.deviceTypes.push(deviceTypeLabel);
+            result.deviceTypes.push({"name": deviceTypeLabel, "value": deviceTypeName});
         }
     }
     //Adding policy compliance

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/public/js/listing.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/public/js/listing.js
@@ -440,7 +440,7 @@ function loadDevices(searchType, searchParam) {
                     break;
                 case 4:
                     $(this).attr('data-grid-label', "Type");
-                    $(this).attr('data-search', deviceType);
+                    $(this).attr('data-search', getDeviceTypeLabel(deviceType));
                     $(this).attr('data-display', getDeviceTypeLabel(deviceType));
                     break;
                 case 5:

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/public/js/listing.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.devices/public/js/listing.js
@@ -440,7 +440,7 @@ function loadDevices(searchType, searchParam) {
                     break;
                 case 4:
                     $(this).attr('data-grid-label', "Type");
-                    $(this).attr('data-search', getDeviceTypeLabel(deviceType));
+                    $(this).attr('data-search', deviceType);
                     $(this).attr('data-display', getDeviceTypeLabel(deviceType));
                     break;
                 case 5:

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.js
@@ -121,7 +121,13 @@ $.fn.datatables_extended = function (settings) {
                             } else if (filterColumn.eq(column.index()).hasClass('data-platform')) {
                                 for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){
                                     var deviceTypes = cachedFilterRes.deviceTypes[i];
-                                    select.append('<option value="' + deviceTypes + '">' + deviceTypes + '</option>')
+                                    var name = deviceTypes;
+                                    var value = deviceTypes;
+                                    if (deviceTypes.name && deviceTypes.value) {
+                                        name = deviceTypes.name;
+                                        value = deviceTypes.value;
+                                    }
+                                    select.append('<option value="' + value + '">' + name + '</option>')
                                 }
                             } else if (filterColumn.eq(column.index()).hasClass('data-compliance')) {
                                 for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.serversidepaging.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.data-tables-extended/public/js/dataTables.extended.serversidepaging.js
@@ -147,10 +147,6 @@ $.fn.datatables_extended_serverside_paging = function (settings, url, dataFilter
                                     } else {
                                         $("#operation-guide").addClass("hidden");
                                         $("#operation-bar").removeClass("hidden");
-                                        //noinspection JSUnresolvedFunction
-                                        if (deviceType && ownership) {
-                                            loadOperationBar(deviceType, ownership, operationBarModeConstants.BULK);
-                                        }
                                     }
                                 }
 
@@ -162,10 +158,6 @@ $.fn.datatables_extended_serverside_paging = function (settings, url, dataFilter
                                     } else {
                                         $("#operation-guide").addClass("hidden");
                                         $("#operation-bar").removeClass("hidden");
-                                        //noinspection JSUnresolvedFunction
-                                        if (deviceType && ownership) {
-                                            loadOperationBar(deviceType, ownership, operationBarModeConstants.BULK);
-                                        }
                                     }
                                 }
                             });
@@ -197,7 +189,13 @@ $.fn.datatables_extended_serverside_paging = function (settings, url, dataFilter
                             } else if (filterColumn.eq(column.index()).hasClass('data-platform')) {
                                 for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){
                                     var deviceTypes = cachedFilterRes.deviceTypes[i];
-                                    select.append('<option value="' + deviceTypes + '">' + deviceTypes + '</option>')
+                                    var name = deviceTypes;
+                                    var value = deviceTypes;
+                                    if (deviceTypes.name && deviceTypes.value) {
+                                        name = deviceTypes.name;
+                                        value = deviceTypes.value;
+                                    }
+                                    select.append('<option value="' + value + '">' + name + '</option>')
                                 }
                             } else if (filterColumn.eq(column.index()).hasClass('data-compliance')) {
                                 for(i = 0; i < cachedFilterRes.deviceTypes.length; i++){


### PR DESCRIPTION
## Purpose
> Platform filter is not working correctly.This PR is related to the https://github.com/wso2-support/carbon-device-mgt/pull/35

## Goals
> Fix the platform filter not working

## Approach
> Platform filter will get a set of name, value pair in order to populate option box.

## User stories
> N/A

## Release note
> Fixing issue of devices listing page platform filter is not working

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A