### PR TITLE
Removing code that leads to an exception when retrieved device count is 0

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -2535,14 +2535,6 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
      * of the given device list.
      */
     private List<Device> getAllDeviceInfo(List<Device> allDevices) throws DeviceManagementException {
-        if (allDevices.size() == 0) {
-            String msg = "Received empty device list for getAllDeviceInfo";
-            log.error(msg);
-            throw new DeviceManagementException(msg);
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("Get all device info of devices, num of devices: " + allDevices.size());
-        }
         List<Device> devices = new ArrayList<>();
         for (Device device : allDevices) {
             device.setDeviceInfo(this.getDeviceInfo(device));

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -2535,6 +2535,9 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
      * of the given device list.
      */
     private List<Device> getAllDeviceInfo(List<Device> allDevices) throws DeviceManagementException {
+        if (log.isDebugEnabled()) {
+            log.debug("Get all device info of devices, num of devices: " + allDevices.size());
+        }
         List<Device> devices = new ArrayList<>();
         for (Device device : allDevices) {
             device.setDeviceInfo(this.getDeviceInfo(device));


### PR DESCRIPTION
## Purpose
> When retrieving devices, there should be no error thrown when device count is 0

## Goals
> When navigating to the store in APPM, whilst 0 devices are enrolled in IoT Server, when the UI loads, there is an error thrown. This will rectify the issue.

## Approach
> Removed DeviceManagementException thrown when retrieved device count is 0

## User stories
> N/A

## Release note
> Fixed exception thrown when device count is 0

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A.