### PR TITLE
Enable user's last name in the email template

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/impl/UserManagementServiceImpl.java
@@ -151,6 +151,7 @@ public class UserManagementServiceImpl implements UserManagementService {
             String recipient = userInfo.getEmailAddress();
             Properties props = new Properties();
             props.setProperty("first-name", userInfo.getFirstname());
+            props.setProperty("last-name", userInfo.getLastname());
             props.setProperty("username", username);
             props.setProperty("password", initialUserPassword);
 
@@ -609,10 +610,15 @@ public class UserManagementServiceImpl implements UserManagementService {
             Properties props = new Properties();
             String username = DeviceMgtAPIUtils.getAuthenticatedUser();
             String firstName = getClaimValue(username, Constants.USER_CLAIM_FIRST_NAME);
+            String lastName = getClaimValue(username, Constants.USER_CLAIM_LAST_NAME);
             if (firstName == null) {
                 firstName = username;
             }
+            if (lastName == null) {
+                lastName = "";
+            }
             props.setProperty("first-name", firstName);
+            props.setProperty("last-name", lastName);
             props.setProperty("device-type", enrollmentInvitation.getDeviceType());
             EmailMetaInfo metaInfo = new EmailMetaInfo(recipients, props);
             dms.sendEnrolmentInvitation(getEnrollmentTemplateName(enrollmentInvitation.getDeviceType()), metaInfo);


### PR DESCRIPTION
This is to enable the user's last name also to be included in the meta information list on email templates. When customizing the email template users can define to include both fist and last name to the content or title of the email

## Purpose
>  Resolves wso2/product-iots#1709.

## Goals
> To enable the user's last name to be included in the email content.

## Approach
> Enable the User's last name from the API level call to be added to the email template by pushing the needed information with the email meta data.


## User stories
> N/A

## Release note
> N/A
## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A
