### PR TITLE
Fix the issue of an error printed when shutting down the IoT Server

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementPluginRepository.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementPluginRepository.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.device.mgt.common.DeviceManagementException;
 import org.wso2.carbon.device.mgt.common.DeviceStatusTaskPluginConfig;
+import org.wso2.carbon.device.mgt.common.InvalidConfigurationException;
 import org.wso2.carbon.device.mgt.common.OperationMonitoringTaskConfig;
 import org.wso2.carbon.device.mgt.common.ProvisioningConfig;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
@@ -153,9 +154,13 @@ public class DeviceManagementPluginRepository implements DeviceManagerStartupLis
         OperationManager operationManager = operationManagerRepository.getOperationManager(
                 deviceTypeIdentifier);
         if (operationManager != null) {
-            NotificationStrategy notificationStrategy = operationManager.getNotificationStrategy();
-            if (notificationStrategy != null) {
-                notificationStrategy.undeploy();
+            try {
+                NotificationStrategy notificationStrategy = operationManager.getNotificationStrategy();
+                if (notificationStrategy != null) {
+                    notificationStrategy.undeploy();
+                }
+            } catch (InvalidConfigurationException ignore) {
+                //error occurred while undeploying strategy, ignore error
             }
             operationManagerRepository.removeOperationManager(deviceTypeIdentifier);
         }


### PR DESCRIPTION
## Purpose
> To fix the issue of an error printed when shutting down the IoT Server.  Resolves https://github.com/wso2/product-iots/issues/1724.

## Goals
> To fix the issue of an error printed when shutting down the IoT Server

## Approach
> To fix the issue of an error printed when shutting down the IoT Server.

## User stories
> N/A

## Release note
> Fix the issue of an error printed when shutting down the IoT Server

## Documentation
> N/A

## Training
> N/A

## Certification
>  N/A

## Marketing
>  N/A

## Automation tests
 - Unit tests 
   >  N/A
 - Integration tests
   >  N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
>  N/A

## Related PRs
>  N/A

## Migrations (if applicable)
>  N/A

## Test environment
>  Apache Maven 3.5.2
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"
 
## Learning
> N/A