### PR TITLE
Fix policy view interface loading issue

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.effective-policy.view/public/js/view.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.effective-policy.view/public/js/view.js
@@ -41,8 +41,7 @@ var displayPolicy = function (policyPayloadObj) {
 
     if (!policyPayloadObj.users) {
         $("#policy-users").text("NONE");
-    }
-    else if (policyPayloadObj.users.length > 0) {
+    } else if (policyPayloadObj.users.length > 0) {
         $("#policy-users").text(policyPayloadObj.users.toString().split(",").join(", "));
     } else {
         $("#users-row").addClass("hidden");
@@ -59,14 +58,11 @@ var displayPolicy = function (policyPayloadObj) {
             }
         }
         $("#policy-groups").text(assignedGroups.toString().split(",").join(", "));
-    } else {
-        $("#policy-groups").text("NONE");
     }
 
     if (!policyPayloadObj.roles) {
         $("#policy-roles").text("NONE");
-    }
-    else if (policyPayloadObj.roles.length > 0) {
+    } else if (policyPayloadObj.roles.length > 0) {
         $("#policy-roles").text(policyPayloadObj.roles.toString().split(",").join(", "));
     } else {
         $("#roles-row").addClass("hidden");

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.view/public/js/view.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.policy.view/public/js/view.js
@@ -41,12 +41,17 @@ var displayPolicy = function (policyPayloadObj) {
 
     $("#policy-status").html(policyStatus);
 
-    if (policyPayloadObj.users.length > 0) {
+    if (!policyPayloadObj.users) {
+        $("#policy-users").text("NONE");
+    } else if (policyPayloadObj.users.length > 0) {
         $("#policy-users").text(policyPayloadObj.users.toString().split(",").join(", "));
     } else {
         $("#users-row").addClass("hidden");
     }
-    if (policyPayloadObj.deviceGroups.length > 0) {
+
+    if (!policyPayloadObj.deviceGroups) {
+        $("#policy-groups").text("NONE");
+    } else if (policyPayloadObj.deviceGroups.length > 0) {
         var deviceGroups = policyPayloadObj.deviceGroups;
         var assignedGroups = [];
         for (var index in deviceGroups) {
@@ -55,14 +60,12 @@ var displayPolicy = function (policyPayloadObj) {
             }
         }
         $("#policy-groups").text(assignedGroups.toString().split(",").join(", "));
-    } else {
-        $("#policy-groups").text("NONE");
     }
 
-    if (policyPayloadObj.roles.length > 0) {
-        $("#policy-roles").text(policyPayloadObj.roles.toString().split(",").join(", "));
-    } else {
+    if (!policyPayloadObj.roles) {
         $("#roles-row").addClass("hidden");
+    } else if (policyPayloadObj.roles.length > 0) {
+        $("#policy-roles").text(policyPayloadObj.roles.toString().split(",").join(", "));
     }
 
     var policyId = policyPayloadObj["id"];


### PR DESCRIPTION
## Purpose
> When the policy view page is loaded some of the variables of the policyPayloadObj becomes undefined or null.  This commit checks for the empty and undefined variables.

Related to wso2/product-iots#1681

## Goals
> Fixing the policy UI not loading issue

## Approach
> Checking for null and empty values in possible places

## User stories
> N/A

## Release note
> Fix policy view interface loading issue

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8.0_161, Ubuntu 16.04, H2, Chrome latest
 
## Learning
> N/A