### PR TITLE
Fix UI loading issue on Safari 11.0.3

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/geo-dashboard.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/geo-dashboard.hbs
@@ -736,6 +736,7 @@
             var geoLocationLink = $(".initGeoLocationLink");
             if (geoLocationLink) {
                 geoLocationLink.on('click', function () {
+                    loadGeoFencing();
                     initializeGeoLocation({{geoServicesEnabled}});
                 });
                 geoPublicUri = $("#geo-charts").data("geo-public-uri");

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/app.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/app.js
@@ -46,7 +46,7 @@ function initialLoad(geoFencingEnabled) {
 }
 
 function initializeMap() {
-    if (typeof(map) !== 'undefined') {
+    if (typeof(map) !== 'undefined' && map.zoomControl != null)  {
         map.remove();
     }
     if (document.getElementById('map') == null) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/app.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/app.js
@@ -46,6 +46,7 @@ function initialLoad(geoFencingEnabled) {
 }
 
 function initializeMap() {
+    ///map.zoomControl is added to fix UI loading issue on Safari
     if (typeof(map) !== 'undefined' && map.zoomControl != null)  {
         map.remove();
     }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_fencing.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_fencing.js
@@ -23,10 +23,8 @@ var drawnItems;
 var lastId;
 var controlDiv;
 
-loadGeoFencing();
-
 function loadGeoFencing() {
-    if (map == null) {
+    if (map == null || map.zoomControl == null) {
         setTimeout(loadGeoFencing, 1000); // give everything some time to render
     } else {
         map.on('draw:created', function (e) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_fencing.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.geo-dashboard/public/js/geo_fencing.js
@@ -24,6 +24,7 @@ var lastId;
 var controlDiv;
 
 function loadGeoFencing() {
+    ///map.zoomControl is added to fix UI loading issue on Safari
     if (map == null || map.zoomControl == null) {
         setTimeout(loadGeoFencing, 1000); // give everything some time to render
     } else {


### PR DESCRIPTION
## Purpose
> Fix the issue of operation logs and location doesn't display on device detail page on safari browser 11.0.3. Fixes wso2/product-iots#1752

## Goals
> Fixing the UI issue on device detail page when loading device location and operation log on Safari 11.0.3

## Approach
> On Safari, map object is incorrectly set and fails some of the checks. Modified the check conditions. 

## User stories
> N/A Bug fix

## Release note
> N/A Bug fix

## Documentation
> N/A Bug fix

## Training
> N/A Bug fix

## Certification
> N/A Bug fix

## Marketing
> N/A Bug fix

## Automation tests
 Cannot automate.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A Bug fix

## Related PRs
> N/A 

## Migrations (if applicable)
> N/A

## Test environment
> Safari 11.0.3
 
## Learning
> N/A Bug fix