### PR TITLE
UI implementation for DEP management of iOS devices

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
@@ -153,7 +153,9 @@
     "perm:admin:device-type",
     "perm:device:enroll",
     "perm:geo-service:analytics-view",
-    "perm:geo-service:alerts-manage"
+    "perm:geo-service:alerts-manage",
+    "perm:ios:dep-add",
+    "perm:ios:dep-view"
   ],
   "isOAuthEnabled": true,
   "backendRestEndpoints": {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
@@ -153,9 +153,7 @@
     "perm:admin:device-type",
     "perm:device:enroll",
     "perm:geo-service:analytics-view",
-    "perm:geo-service:alerts-manage",
-    "perm:ios:dep-add",
-    "perm:ios:dep-view"
+    "perm:geo-service:alerts-manage"
   ],
   "isOAuthEnabled": true,
   "backendRestEndpoints": {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
@@ -120,6 +120,11 @@
                             Certificate Configurations
                         </a>
                     </li>
+                    <li>
+                        <a href="{{@app.context}}/dep/devices"><i class="fw fw-apple"></i>
+                            DEP Configurations
+                        </a>
+                    </li>
                 </ul>
             </li>
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
@@ -120,13 +120,13 @@
                             Certificate Configurations
                         </a>
                     </li>
-                    {{#unless iosPluginFlag}}
+                    {{#if iosPluginFlag}}
                         <li>
                             <a href="{{@app.context}}/dep/devices"><i class="fw fw-apple"></i>
                                 DEP Configurations
                             </a>
                         </li>
-                    {{/unless}}
+                    {{/if}}
                 </ul>
             </li>
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
@@ -120,11 +120,13 @@
                             Certificate Configurations
                         </a>
                     </li>
-                    <li>
-                        <a href="{{@app.context}}/dep/devices"><i class="fw fw-apple"></i>
-                            DEP Configurations
-                        </a>
-                    </li>
+                    {{#unless iosPluginFlag}}
+                        <li>
+                            <a href="{{@app.context}}/dep/devices"><i class="fw fw-apple"></i>
+                                DEP Configurations
+                            </a>
+                        </li>
+                    {{/unless}}
                 </ul>
             </li>
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.js
@@ -28,6 +28,7 @@ function onRequest(context) {
         }
     });
     var userModule = require("/app/modules/business-controllers/user.js")["userModule"];
+    var deviceModule = require("/app/modules/business-controllers/device.js")["deviceModule"];
     var mdmProps = require("/app/modules/conf-reader/main.js")["conf"];
     var constants = require("/app/modules/constants.js");
     var uiPermissions = userModule.getUIPermissions();
@@ -40,6 +41,17 @@ function onRequest(context) {
         "policy-mgt": [],
         "device-mgt": []
     };
+
+    var typesListResponse = deviceModule.getDeviceTypesConfig();
+    var temp = [];
+    temp = typesListResponse["content"];
+    var iosPluginFlag = false;
+    temp.forEach(function(element) {
+        if (element["name"] == "ios") {
+            iosPluginFlag = true;
+        }
+    });
+    context["iosPluginFlag"] = iosPluginFlag;
 
     // following context.link value comes here based on the value passed at the point
     // where units are attached to a page zone.


### PR DESCRIPTION
## Purpose
> To include UI implementation of DEP management for iOS devices.

## Goals
> Allows adding, removing and viewing iOS devices as well as profiles in DEP.

## Approach
> ![dep_screenshot](https://user-images.githubusercontent.com/24616975/37267572-344269f6-25e7-11e8-856a-2cb6f2d251e5.png)

## User stories
> As a system administrator, I can add profiles to DEP.
> As a system administrator I can view profiles in DEP.

## Release note
> DEP management of iOS devices

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
> N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK version: java 1.8.0_141
Operating System: Linux Ubuntu
Browser version: Google Chrome 65
 
## Learning
> N/A