### PR TITLE
Fix OAuth2ScopeValidator Issues

### DIFF
--- a/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/pom.xml
+++ b/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/pom.xml
@@ -110,7 +110,8 @@
 							org.wso2.carbon.identity.base;version="${carbon.identity.framework.version.range}",
 							org.wso2.carbon.identity.oauth2.*;version="${carbon.identity.framework.version.range}",
 							org.wso2.carbon.utils.multitenancy,
-                            org.apache.oltu.oauth2.common.validators
+                            org.apache.oltu.oauth2.common.validators,
+                            org.apache.commons.lang3.tuple,
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/src/main/java/org/wso2/carbon/device/mgt/oauth/extensions/validators/ExtendedJDBCScopeValidator.java
+++ b/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/src/main/java/org/wso2/carbon/device/mgt/oauth/extensions/validators/ExtendedJDBCScopeValidator.java
@@ -28,11 +28,9 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth.cache.CacheEntry;
 import org.wso2.carbon.identity.oauth.cache.OAuthCache;
 import org.wso2.carbon.identity.oauth.cache.OAuthCacheKey;
-import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
-import org.wso2.carbon.identity.oauth2.dao.OAuthScopeDAO;
 import org.wso2.carbon.identity.oauth2.dao.OAuthScopeDAOImpl;
-import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
+import org.wso2.carbon.identity.oauth2.dao.TokenManagementDAOImpl;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.model.ResourceScopeCacheEntry;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
@@ -64,12 +62,12 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
         }
 
         String resourceScope = null;
-//        TokenMgtDAO tokenMgtDAO = new TokenMgtDAO();
         OAuthScopeDAOImpl scopeDAO = new OAuthScopeDAOImpl();
-
+        TokenManagementDAOImpl tokenManagementDAO = new TokenManagementDAOImpl();
         boolean cacheHit = false;
+
         // Check the cache, if caching is enabled.
-        if (OAuthServerConfiguration.getInstance().isCacheEnabled()) {
+        if (OAuthCache.getInstance().isEnabled()) {
             OAuthCache oauthCache = OAuthCache.getInstance();
             OAuthCacheKey cacheKey = new OAuthCacheKey(resource);
             CacheEntry result = oauthCache.getValueFromCache(cacheKey);
@@ -82,9 +80,9 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
         }
 
         if (!cacheHit) {
-            resourceScope = scopeDAO.findScopeOfResource(resource);
+            resourceScope = tokenManagementDAO.findTenantAndScopeOfResource(resource).getKey();
 
-            if (OAuthServerConfiguration.getInstance().isCacheEnabled()) {
+            if (OAuthCache.getInstance().isEnabled()) {
                 OAuthCache oauthCache = OAuthCache.getInstance();
                 OAuthCacheKey cacheKey = new OAuthCacheKey(resource);
                 ResourceScopeCacheEntry cacheEntry = new ResourceScopeCacheEntry(resourceScope);
@@ -96,7 +94,7 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
 
         //Return TRUE if - There does not exist a scope definition for the resource
         if (resourceScope == null) {
-            if(log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 log.debug("Resource '" + resource + "' is not protected with a scope");
             }
             return true;
@@ -105,39 +103,39 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
         List<String> scopeList = new ArrayList<>(Arrays.asList(scopes));
 
         //If the access token does not bear the scope required for accessing the Resource.
-        if(!scopeList.contains(resourceScope)){
-            if(log.isDebugEnabled()){
+        if (!scopeList.contains(resourceScope)) {
+            if (log.isDebugEnabled()) {
                 log.debug("Access token '" + accessTokenDO.getAccessToken() + "' does not bear the scope '" +
-                        resourceScope + "'");
+                                  resourceScope + "'");
             }
             return false;
         }
 
         try {
+            User authorizedUser = accessTokenDO.getAuthzUser();
+            RealmService realmService = OAuthExtensionsDataHolder.getInstance().getRealmService();
+            int tenantId = realmService.getTenantManager().getTenantId(authorizedUser.getTenantDomain());
+
             //Get the permissions associated with the scope, if any
-            Set<String> permissionsOfScope = scopeDAO.getBindingsOfScopeByScopeName(resourceScope);
+            Set<String> permissionsOfScope = scopeDAO.getBindingsOfScopeByScopeName(resourceScope, tenantId);
 
             //If the scope doesn't have any permissions associated with it.
-            if(permissionsOfScope == null || permissionsOfScope.isEmpty()){
-                if(log.isDebugEnabled()){
+            if (permissionsOfScope == null || permissionsOfScope.isEmpty()) {
+                if (log.isDebugEnabled()) {
                     log.debug("Did not find any roles associated to the scope " + resourceScope);
                 }
                 return true;
             }
 
-            if(log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 StringBuilder logMessage = new StringBuilder("Found permissions of scope '" + resourceScope + "' ");
-                for(String permission : permissionsOfScope){
+                for (String permission : permissionsOfScope) {
                     logMessage.append(permission);
                     logMessage.append(", ");
                 }
                 log.debug(logMessage.toString());
             }
 
-            User authorizedUser = accessTokenDO.getAuthzUser();
-            RealmService realmService = OAuthExtensionsDataHolder.getInstance().getRealmService();
-
-            int tenantId = realmService.getTenantManager().getTenantId(authorizedUser.getTenantDomain());
 
             if (tenantId == 0 || tenantId == -1) {
                 tenantId = IdentityTenantUtil.getTenantIdOfUser(authorizedUser.getUserName());
@@ -147,12 +145,12 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
             String[] userRoles;
             boolean tenantFlowStarted = false;
 
-            try{
+            try {
                 //If this is a tenant user
-                if(tenantId != MultitenantConstants.SUPER_TENANT_ID){
+                if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
                     PrivilegedCarbonContext.startTenantFlow();
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
-                            realmService.getTenantManager().getDomain(tenantId),true);
+                            realmService.getTenantManager().getDomain(tenantId), true);
                     tenantFlowStarted = true;
                 }
 
@@ -173,7 +171,7 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
                         status = authorizationManager
                                 .isUserAuthorized(userStore + "/" + username, permission, UI_EXECUTE);
                     } else {
-                        status = authorizationManager.isUserAuthorized(username , permission, UI_EXECUTE);
+                        status = authorizationManager.isUserAuthorized(username, permission, UI_EXECUTE);
                     }
                     if (status) {
                         break;
@@ -182,13 +180,13 @@ public class ExtendedJDBCScopeValidator extends OAuth2ScopeValidator {
             }
 
             if (status) {
-                if(log.isDebugEnabled()){
+                if (log.isDebugEnabled()) {
                     log.debug("User '" + authorizedUser.getUserName() + "' is authorized");
                 }
                 return true;
             }
 
-            if(log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 log.debug("No permissions associated for the user " + authorizedUser.getUserName());
             }
             return false;

--- a/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/src/main/java/org/wso2/carbon/device/mgt/oauth/extensions/validators/PermissionBasedScopeValidator.java
+++ b/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/src/main/java/org/wso2/carbon/device/mgt/oauth/extensions/validators/PermissionBasedScopeValidator.java
@@ -27,9 +27,7 @@ import org.wso2.carbon.identity.application.common.model.User;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.OAuthScopeDAO;
-import org.wso2.carbon.identity.oauth2.dao.OAuthScopeDAOImpl;
 import org.wso2.carbon.identity.oauth2.dao.OAuthTokenPersistenceFactory;
-import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
 import org.wso2.carbon.user.api.AuthorizationManager;
@@ -59,44 +57,19 @@ public class PermissionBasedScopeValidator extends OAuth2ScopeValidator {
             return true;
         }
 
-        OAuthScopeDAO pp = OAuthTokenPersistenceFactory.getInstance().getOAuthScopeDAO();
-        int tid = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
-
-//        TokenMgtDAO tokenMgtDAO = new TokenMgtDAO();
-        OAuthScopeDAOImpl nn = new OAuthScopeDAOImpl();
-
+        OAuthScopeDAO authScopeDAO = OAuthTokenPersistenceFactory.getInstance().getOAuthScopeDAO();
         List<String> scopeList = new ArrayList<>(Arrays.asList(scopes));
 
         //If the access token does not bear the scope required for accessing the Resource.
-        if(!scopeList.contains(resourceScope)){
-            if(log.isDebugEnabled()){
+        if (!scopeList.contains(resourceScope)) {
+            if (log.isDebugEnabled()) {
                 log.debug("Access token '" + accessTokenDO.getAccessToken() + "' does not bear the scope '" +
-                        resourceScope + "'");
+                                  resourceScope + "'");
             }
             return false;
         }
 
         try {
-            //Get the permissions associated with the scope, if any
-            Set<String> permissionsOfScope = pp.getBindingsOfScopeByScopeName(resourceScope, tid);
-
-            //If the scope doesn't have any permissions associated with it.
-            if(permissionsOfScope == null || permissionsOfScope.isEmpty()){
-                if(log.isDebugEnabled()){
-                    log.debug("Did not find any roles associated to the scope " + resourceScope);
-                }
-                return true;
-            }
-
-            if(log.isDebugEnabled()){
-                StringBuilder logMessage = new StringBuilder("Found permissions of scope '" + resourceScope + "' ");
-                for(String permission : permissionsOfScope){
-                    logMessage.append(permission);
-                    logMessage.append(", ");
-                }
-                log.debug(logMessage.toString());
-            }
-
             User authorizedUser = accessTokenDO.getAuthzUser();
             RealmService realmService = OAuthExtensionsDataHolder.getInstance().getRealmService();
 
@@ -105,17 +78,36 @@ public class PermissionBasedScopeValidator extends OAuth2ScopeValidator {
             if (tenantId == 0 || tenantId == -1) {
                 tenantId = IdentityTenantUtil.getTenantIdOfUser(authorizedUser.getUserName());
             }
+            //Get the permissions associated with the scope, if any
+            Set<String> permissionsOfScope = authScopeDAO.getBindingsOfScopeByScopeName(resourceScope, tenantId);
+
+            //If the scope doesn't have any permissions associated with it.
+            if (permissionsOfScope == null || permissionsOfScope.isEmpty()) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Did not find any roles associated to the scope " + resourceScope);
+                }
+                return true;
+            }
+
+            if (log.isDebugEnabled()) {
+                StringBuilder logMessage = new StringBuilder("Found permissions of scope '" + resourceScope + "' ");
+                for (String permission : permissionsOfScope) {
+                    logMessage.append(permission);
+                    logMessage.append(", ");
+                }
+                log.debug(logMessage.toString());
+            }
 
             AuthorizationManager authorizationManager;
             String[] userRoles;
             boolean tenantFlowStarted = false;
 
-            try{
+            try {
                 //If this is a tenant user
-                if(tenantId != MultitenantConstants.SUPER_TENANT_ID){
+                if (tenantId != MultitenantConstants.SUPER_TENANT_ID) {
                     PrivilegedCarbonContext.startTenantFlow();
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(
-                            realmService.getTenantManager().getDomain(tenantId),true);
+                            realmService.getTenantManager().getDomain(tenantId), true);
                     tenantFlowStarted = true;
                 }
 
@@ -136,7 +128,7 @@ public class PermissionBasedScopeValidator extends OAuth2ScopeValidator {
                         status = authorizationManager
                                 .isUserAuthorized(userStore + "/" + username, permission, UI_EXECUTE);
                     } else {
-                        status = authorizationManager.isUserAuthorized(username , permission, UI_EXECUTE);
+                        status = authorizationManager.isUserAuthorized(username, permission, UI_EXECUTE);
                     }
                     if (status) {
                         break;
@@ -145,13 +137,13 @@ public class PermissionBasedScopeValidator extends OAuth2ScopeValidator {
             }
 
             if (status) {
-                if(log.isDebugEnabled()){
+                if (log.isDebugEnabled()) {
                     log.debug("User '" + authorizedUser.getUserName() + "' is authorized");
                 }
                 return true;
             }
 
-            if(log.isDebugEnabled()){
+            if (log.isDebugEnabled()) {
                 log.debug("No permissions associated for the user " + authorizedUser.getUserName());
             }
             return false;

--- a/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/src/main/java/org/wso2/carbon/device/mgt/oauth/extensions/validators/RoleBasedScopeValidator.java
+++ b/components/identity-extensions/org.wso2.carbon.device.mgt.oauth.extensions/src/main/java/org/wso2/carbon/device/mgt/oauth/extensions/validators/RoleBasedScopeValidator.java
@@ -29,7 +29,6 @@ import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dao.OAuthScopeDAOImpl;
-import org.wso2.carbon.identity.oauth2.dao.TokenMgtDAO;
 import org.wso2.carbon.identity.oauth2.model.AccessTokenDO;
 import org.wso2.carbon.identity.oauth2.validators.OAuth2ScopeValidator;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -62,9 +61,7 @@ public class RoleBasedScopeValidator extends OAuth2ScopeValidator {
             return true;
         }
 
-//        TokenMgtDAO tokenMgtDAO = new TokenMgtDAO();
         OAuthScopeDAOImpl scopeDAO = new OAuthScopeDAOImpl();
-
         List<String> scopeList = new ArrayList<>(Arrays.asList(scopes));
 
         //If the access token does not bear the scope required for accessing the Resource.
@@ -77,8 +74,15 @@ public class RoleBasedScopeValidator extends OAuth2ScopeValidator {
         }
 
         try {
+            User authzUser = accessTokenDO.getAuthzUser();
+            RealmService realmService = OAuthExtensionsDataHolder.getInstance().getRealmService();
+            int tenantId = realmService.getTenantManager().getTenantId(authzUser.getTenantDomain());
+            if (tenantId == 0 || tenantId == -1) {
+                tenantId = IdentityTenantUtil.getTenantIdOfUser(authzUser.getUserName());
+            }
+
             //Get the roles associated with the scope, if any
-            Set<String> rolesOfScope = scopeDAO.getBindingsOfScopeByScopeName(resourceScope);
+            Set<String> rolesOfScope = scopeDAO.getBindingsOfScopeByScopeName(resourceScope, tenantId);
 
             //If the scope doesn't have any roles associated with it.
             if(rolesOfScope == null || rolesOfScope.isEmpty()){
@@ -95,16 +99,6 @@ public class RoleBasedScopeValidator extends OAuth2ScopeValidator {
                     logMessage.append(", ");
                 }
                 log.debug(logMessage.toString());
-            }
-
-            User authzUser = accessTokenDO.getAuthzUser();
-            RealmService realmService = OAuthExtensionsDataHolder.getInstance().getRealmService();
-
-            int tenantId = realmService.getTenantManager().
-                    getTenantId(authzUser.getTenantDomain());
-
-            if (tenantId == 0 || tenantId == -1) {
-                tenantId = IdentityTenantUtil.getTenantIdOfUser(authzUser.getUserName());
             }
 
             UserStoreManager userStoreManager;


### PR DESCRIPTION
## Purpose
> Due to the version bumping of the identity component, there were some references to the deprecated methods. Hence removed those and referred approved methods. In addition to that, to compatible with WSO2 cording standards, reformat the source as well.

## Goals
> We had called "isCacheEnabled" of the "OAuthServerConfiguration" class to check whether the cache is enabled or not. Since it is a deprecated method, used OAuthCache class to check whether cache enables or not. In addition to that, "TokenManagementDAOImpl" class is referred instead of "TokenMgtDAO" class.

## Approach
> N/A

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A