### PR TITLE
Adding an extension point into the PaginationRequest class

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/PaginationRequest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/PaginationRequest.java
@@ -19,6 +19,8 @@
 package org.wso2.carbon.device.mgt.common;
 
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class holds required parameters for a querying a paginated device response.
@@ -35,6 +37,7 @@ public class PaginationRequest {
     private String deviceName;
     private String ownership;
     private String ownerRole;
+    private Map<String, Object> property = new HashMap<>();
     private Date since;
 
     public PaginationRequest(int start, int rowCount) {
@@ -128,6 +131,24 @@ public class PaginationRequest {
 
     public void setOwnerPattern(String ownerPattern) {
         this.ownerPattern = ownerPattern;
+    }
+
+    public void setProperty(String key, Object value) {
+        this.property.put(key, value);
+    }
+
+    public void setProperties(Map<String, Object> parameters) {
+        this.property.putAll(parameters);
+    }
+
+    public void getProperty(String key) {
+        this.property.get(key);
+    }
+
+    public Map<String, Object> getProperties() {
+        Map<String, Object> temp = new HashMap<>();
+        temp.putAll(property);
+        return temp;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> This allows other APIs which has additional parameters to be passed into
the backend DAOs.

## Goals
> Allowing additional parameters into the PaginationRequest.

## Approach
> Added an extension point into the PaginationRequest addParameter, addParameters, getParameter, getParameters.

## User stories
> N/A

## Release note
> Adding extension points into the PaginationRequest.

## Documentation
> N/A

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Sample 1:
PaginationRequest request = new PaginationRequest();
request.setProperty("name", "abc");
request.getProperty("name");
> 
> Sample 2:
> PaginationRequest request = new PaginationRequest();
Map<String, Object> props= new HashMap<>();
props.put("name", "abc");
props.put("department", "def");
request.setProperties(props);
>
> request.getProperties();

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Apache Maven 3.5.2 
Maven home: /usr/local/Cellar/maven/3.5.2/libexec
Java version: 1.8.0_152, vendor: Oracle Corporation
Java home: /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre
Default locale: en_LK, platform encoding: UTF-8
OS name: "mac os x", version: "10.13.3", arch: "x86_64", family: "mac"

## Learning
> N/A