### PR TITLE
Generate nav menu icons based on correct permissions

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/modules/business-controllers/user.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/modules/business-controllers/user.js
@@ -605,8 +605,11 @@ var userModule = function () {
         if (publicMethods.isAuthorized("/permission/admin/device-mgt/dashboard/view")) {
             permissions["VIEW_DASHBOARD"] = true;
         }
-        if (publicMethods.isAuthorized("/permission/admin/device-mgt/platform-configs/view")) {
+        if (publicMethods.isAuthorized("/permission/admin/device-mgt/platform-configurations/view")) {
             permissions["TENANT_CONFIGURATION"] = true;
+        }
+        if (publicMethods.isAuthorized("/permission/admin/device-mgt/certificates/manage")) {
+            permissions["CERTIFICATE_MANAGEMENT"] = true;
         }
         if (publicMethods.isAuthorized("/permission/admin/device-mgt/devices/change-status")) {
             permissions["CHANGE_DEVICE_STATUS"] = true;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.hbs
@@ -29,8 +29,6 @@
                 Device Management
             </a>
         </li>
-    {{/if}}
-    {{#if permissions.IS_ADMIN}}
         <li>
             <a href="{{@app.context}}/device-types">
                 <i class="fw fw-devices"></i>
@@ -90,11 +88,11 @@
             </ul>
         </li>
     {{/if}}
-    {{#if permissions.LIST_POLICIES}}
+    {{#if permissions.LIST_ALL_POLICIES}}
         <li><a href="{{@app.context}}/policies"><i class="fw fw-policy"></i>Policy Management</a></li>
     {{/if}}
 
-    {{#if permissions.TENANT_CONFIGURATION}}
+    {{#if configMgtEnabled}}
         {{#if isCloud}}
 
             <li>
@@ -109,17 +107,15 @@
             <li>
                 <a><i class="fw fw-settings"></i>Configuration Management</a>
                 <ul>
-                    <li>
-                        <a href="{{@app.context}}/platform-configuration"><i class="fw fw-service"></i>
-                            Platform Configurations
-                        </a>
-                    </li>
-                    <!-- todo change the permission and get the related permission -->
-                    <li>
-                        <a href="{{@app.context}}/certificates"><i class="fw fw-security-policy"></i>
-                            Certificate Configurations
-                        </a>
-                    </li>
+                    {{#if permissions.TENANT_CONFIGURATION}}
+                        <li><a href="{{@app.context}}/platform-configuration"><i class="fw fw-service"></i>Platform Configurations</a>
+                        </li>
+                    {{/if}}
+                    {{#if permissions.CERTIFICATE_MANAGEMENT}}
+                        <!-- todo change the permission and get the related permission -->
+                        <li><a href="{{@app.context}}/certificates"><i class="fw fw-security-policy"></i>Certificate Configurations</a>
+                        </li>
+                    {{/if}}
                     {{#if iosPluginFlag}}
                         <li>
                             <a href="{{@app.context}}/dep/devices"><i class="fw fw-apple"></i>
@@ -138,11 +134,7 @@
                 <i class="fw fw-map-location"></i>
                 Device Locations
             </a>
-        </li>
     {{/if}}
-
-
-
 {{/zone}}
 
 {{#zone "navbarCollapsableRightItems"}}

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/units/cdmf.unit.ui.navbar.nav-menu/nav-menu.js
@@ -34,6 +34,7 @@ function onRequest(context) {
     var uiPermissions = userModule.getUIPermissions();
     context["permissions"] = uiPermissions;
     context["userMgtEnabled"] = (uiPermissions["LIST_USERS"] || uiPermissions["LIST_ROLES"]);
+    context["configMgtEnabled"] = (uiPermissions["CERTIFICATE_MANAGEMENT"] || uiPermissions["TENANT_CONFIGURATION"]);
 
     var links = {
         "user-mgt": [],


### PR DESCRIPTION
## Purpose
> Fixing the mismatching permissions which are checked while generating navigation menu icons.
- Correct the wrong permission string used for configuration management.
- Introduce a new UI permission for certificate management.
- Move device type link under "owning device permission" which is the permission declared in the JAX-RS implementation.

Resolves wso2/product-iots#1782

## Goals
> Enabling the correct nav menu icons when the user has permissions.

## Approach
> Checking the correct permissions when the nav icons are generated.

## User stories
> N/A

## Release note
> View correct navigation menu icons related to user permission.

## Documentation
> N/A, This is a bug fix

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8.0_161, Ubuntu 16.04, MySQL 5.6/ H2, Chrome latest stable
 
## Learning
> N/A