### PR TITLE
Hide 'Select All' option when there're only single mandatory claim.

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.sign-in.consent-do/consent-do.hbs
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.sign-in.consent-do/consent-do.hbs
@@ -31,12 +31,14 @@
             <div class="panel-body">
                 <form id="consentForm" method="POST" action="/commonauth">
                     <p>By selecting following attributes I agree to share them with the above service provider.</p>
+                    {{#unless singleMandatoryClaim}}
                     <div class="wr-input-control">
                         <label class="wr-input-control checkbox">
                             <input type="checkbox" name="consent_select_all" id="consent_select_all"/>
                             <span class="helper" title="Select All">Select All</span>
                         </label>
                     </div>
+                    {{/unless}}
                     <div class="wr-input-control">
                     {{#each mandatoryClaims}}
                         <label class="wr-input-control checkbox">

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.sign-in.consent-do/consent-do.js
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/pages/cdmf.page.sign-in.consent-do/consent-do.js
@@ -4,11 +4,13 @@ function onRequest(context) {
     viewModel.appName = Encode.forHtml(request.getParameter("sp"));
     var mandatoryClaims = [];
     var requestedClaims = [];
+    var singleMandatoryClaim = false;
 
     var mandatoryClaimsList, requestedClaimsList;
     var i, j, partOne, partTwo;
     if (request.getParameter("mandatoryClaims")) {
         mandatoryClaimsList = request.getParameter("mandatoryClaims").split(",");
+        singleMandatoryClaim = (mandatoryClaimsList.length === 1);
         for (j = 0; j < mandatoryClaimsList.length; j++) {
             var mandatoryClaimsStr = mandatoryClaimsList[j];
             i = mandatoryClaimsStr.indexOf('_');
@@ -33,6 +35,7 @@ function onRequest(context) {
     }
     viewModel.mandatoryClaims = mandatoryClaims;
     viewModel.requestedClaims = requestedClaims;
+    viewModel.singleMandatoryClaim = singleMandatoryClaim;
     viewModel.sessionDataKey = Encode.forHtmlAttribute(request.getParameter("sessionDataKey"));
     return viewModel;
 }


### PR DESCRIPTION
## Purpose
> Hide 'Select All' option when there're only single mandatory claim.

## Goals
> Hide 'Select All' option when there're only single mandatory claim.

## Approach
> Hide 'Select All' option when there're only single mandatory claim.

## User stories
> N/A

## Release note
> Hide 'Select All' option when there're only single mandatory claim.

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8_u144, Mac OS
 
## Learning
> N/A