### PR TITLE
Add capability to WSO2 IOT server to route HTTP/HTTPS calls through Proxy server

### DIFF
--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/pom.xml
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/pom.xml
@@ -72,7 +72,7 @@
 							javax.xml,
 							org.wso2.carbon.base,
 							javax.net.ssl,
-							feign.okhttp; version="[9.3.1, 9.4.0)",
+							feign.okhttp; version=${github.openfeign.version},
 							okhttp3,
 							org.apache.commons.lang
 						</Import-Package>

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/pom.xml
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/pom.xml
@@ -72,6 +72,9 @@
 							javax.xml,
 							org.wso2.carbon.base,
 							javax.net.ssl,
+							feign.okhttp; version="[9.3.1, 9.4.0)",
+							okhttp3,
+							org.apache.commons.lang
 						</Import-Package>
 						<Embed-Dependency>
 							jsr311-api,
@@ -110,6 +113,14 @@
 	</build>
 
 	<dependencies>
+		<dependency>
+			<groupId>com.squareup.okhttp3</groupId>
+			<artifactId>okhttp</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.openfeign</groupId>
+			<artifactId>feign-okhttp</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.wso2.carbon</groupId>
 			<artifactId>org.wso2.carbon.logging</artifactId>

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/OAuthRequestInterceptor.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/OAuthRequestInterceptor.java
@@ -22,6 +22,7 @@ import feign.auth.BasicAuthRequestInterceptor;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
 import feign.jaxrs.JAXRSContract;
+import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -65,8 +66,9 @@ public class OAuthRequestInterceptor implements RequestInterceptor {
     public OAuthRequestInterceptor() {
         String username = APIMConfigReader.getInstance().getConfig().getUsername();
         String password = APIMConfigReader.getInstance().getConfig().getPassword();
-        dcrClient = Feign.builder().client(Utils.getSSLClient()).logger(new Slf4jLogger()).logLevel(
-                Logger.Level.FULL).requestInterceptor(new BasicAuthRequestInterceptor(username, password))
+        dcrClient = Feign.builder().client(new OkHttpClient(Utils.getSSLClient())).logger(new Slf4jLogger())
+                .logLevel(Logger.Level.FULL).requestInterceptor(new BasicAuthRequestInterceptor(username,
+                        password))
                 .contract(new JAXRSContract()).encoder(new GsonEncoder()).decoder(new GsonDecoder())
                 .target(DCRClient.class, Utils.replaceProperties(
                         APIMConfigReader.getInstance().getConfig().getDcrEndpoint()));

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/publisher/PublisherClient.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/publisher/PublisherClient.java
@@ -22,6 +22,7 @@ import feign.Logger;
 import feign.RequestInterceptor;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -49,8 +50,9 @@ public class PublisherClient {
      *
      */
     public PublisherClient(RequestInterceptor requestInterceptor) {
-        Feign.Builder builder = Feign.builder().client(
-                org.wso2.carbon.apimgt.integration.client.util.Utils.getSSLClient()).logger(new Slf4jLogger())
+        Feign.Builder builder = Feign.builder().client(new OkHttpClient(
+                org.wso2.carbon.apimgt.integration.client.util.Utils.getSSLClient())).logger(new
+                Slf4jLogger())
                 .logLevel(Logger.Level.FULL)
                 .requestInterceptor(requestInterceptor).encoder(new GsonEncoder()).decoder(new GsonDecoder());
         String basePath = Utils.replaceSystemProperty(APIMConfigReader.getInstance().getConfig().getPublisherEndpoint());

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/store/StoreClient.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/store/StoreClient.java
@@ -24,6 +24,7 @@ import feign.RequestInterceptor;
 import feign.Retryer;
 import feign.gson.GsonDecoder;
 import feign.gson.GsonEncoder;
+import feign.okhttp.OkHttpClient;
 import feign.slf4j.Slf4jLogger;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.apimgt.integration.client.configs.APIMConfigReader;
@@ -52,8 +53,9 @@ public class StoreClient {
 
     public StoreClient(RequestInterceptor requestInterceptor) {
 
-        Feign.Builder builder = Feign.builder().client(
-                org.wso2.carbon.apimgt.integration.client.util.Utils.getSSLClient()).logger(new Slf4jLogger())
+        Feign.Builder builder = Feign.builder().client(new OkHttpClient(
+                org.wso2.carbon.apimgt.integration.client.util.Utils.getSSLClient())).logger(new
+                Slf4jLogger())
                 .logLevel(Logger.Level.FULL)
                 .requestInterceptor(requestInterceptor).encoder(new GsonEncoder()).decoder(new GsonDecoder());
         String basePath = Utils.replaceSystemProperty(APIMConfigReader.getInstance().getConfig().getStoreEndpoint());

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
@@ -103,7 +103,8 @@ public class Utils {
 
                 final String host = uri.getHost();
 
-                if (StringUtils.contains(nonProxyHostsValue, host)) {
+                if (host.startsWith("127.0.0.1") || host.startsWith("localhost") || StringUtils.contains
+                        (nonProxyHostsValue, host)) {
                     proxyList.add(Proxy.NO_PROXY);
                 } else {
                     proxyList.add(new Proxy(Proxy.Type.HTTP,

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
@@ -103,7 +103,7 @@ public class Utils {
 
                 final String host = uri.getHost();
 
-                if (host.startsWith("127.0.0.1") || StringUtils.contains(nonProxyHostsValue, host)) {
+                if (StringUtils.contains(nonProxyHostsValue, host)) {
                     proxyList.add(Proxy.NO_PROXY);
                 } else {
                     proxyList.add(new Proxy(Proxy.Type.HTTP,

--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
@@ -101,14 +101,11 @@ public class Utils {
             public java.util.List<Proxy> select(final URI uri) {
                 final List<Proxy> proxyList = new ArrayList<Proxy>(1);
 
-                // Host
                 final String host = uri.getHost();
 
-                // Is an internal host
                 if (host.startsWith("127.0.0.1") || StringUtils.contains(nonProxyHostsValue, host)) {
                     proxyList.add(Proxy.NO_PROXY);
                 } else {
-                    // Add proxy
                     proxyList.add(new Proxy(Proxy.Type.HTTP,
                             new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort))));
                 }
@@ -122,7 +119,6 @@ public class Utils {
             }
         };
 
-//        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort)));
         X509TrustManager trustAllCerts = new X509TrustManager() {
                     public java.security.cert.X509Certificate[] getAcceptedIssuers() {
                         return new java.security.cert.X509Certificate[0];

--- a/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/main/java/org/wso2/carbon/identity/jwt/client/extension/util/JWTClientUtil.java
+++ b/components/identity-extensions/org.wso2.carbon.identity.jwt.client.extension/src/main/java/org/wso2/carbon/identity/jwt/client/extension/util/JWTClientUtil.java
@@ -97,7 +97,7 @@ public class JWTClientUtil {
 			SSLContextBuilder builder = new SSLContextBuilder();
 			builder.loadTrustMaterial(null, new TrustSelfSignedStrategy());
 			SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(builder.build());
-			httpclient = HttpClients.custom().setSSLSocketFactory(sslsf).build();
+			httpclient = HttpClients.custom().setSSLSocketFactory(sslsf).useSystemProperties().build();
 		} else {
 			httpclient = HttpClients.createDefault();
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -1239,6 +1239,16 @@
                 <version>${google.gson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${squareup.okhttp3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.github.openfeign</groupId>
+                <artifactId>feign-okhttp</artifactId>
+                <version>${github.openfeign.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${apache.http.version}</version>
@@ -1971,6 +1981,8 @@
         <commons-json.version>3.0.0.wso2v1</commons-json.version>
         <json.smart.version>1.3</json.smart.version>
         <google.gson.version>2.3.1</google.gson.version>
+        <squareup.okhttp3.version>3.8.1</squareup.okhttp3.version>
+        <github.openfeign.version>9.3.1</github.openfeign.version>
         <jsr311.version>1.1.1</jsr311.version>
         <commons.logging.version>1.2</commons.logging.version>
         <apache.http.version>4.5.1</apache.http.version>


### PR DESCRIPTION
## Purpose
> In an IoT server cluster setup if we configure the worker or manager node calls to be routed through a proxy the communication fails. Purpose of this PR is to fix this issue. Resolves wso2/product-iots#1806

## Goals
> It appears that certain HTTP calls from IoT Server's worker node to the gateway is bypassing the configured proxy. This could be due to the HTTP client that we are using. We use library call Feign in IoT server. Feign is a Java to HTTP client binder. Hence goal is to enable the HTTP calls to be the route through a configured proxy.  

## Approach
> Feign client is not supporting proxy routing this fix has included okhttp client and pass it to the feigns okkhttp client wrapper in order to pass HTTP/HTTPS call through proxy server if the system proxy properties are set. Further this modifies the apache http client also to pick system properties.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Can not automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> On a WSO2 clustered environment 
 
## Learning
> WSO2 IoT Server clustering, HTTP/S call routing