### PR TITLE
Make proxy configuration optional

### DIFF
--- a/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
+++ b/components/apimgt-extensions/org.wso2.carbon.apimgt.integration.client/src/main/java/org/wso2/carbon/apimgt/integration/client/util/Utils.java
@@ -71,6 +71,10 @@ public class Utils {
 
     private static final String SSLV3 = "SSLv3";
 
+    private static final String DEFAULT_HOST = "localhost";
+
+    private static final String DEFAULT_HOST_IP = "127.0.0.1";
+
 
     //This method is only used if the mb features are within DAS.
     public static String replaceProperties(String text) {
@@ -98,19 +102,22 @@ public class Utils {
 
         final ProxySelector proxySelector = new ProxySelector() {
             @Override
-            public java.util.List<Proxy> select(final URI uri) {
-                final List<Proxy> proxyList = new ArrayList<Proxy>(1);
+            public java.util.List<Proxy> select(URI uri) {
+                List<Proxy> proxyList = new ArrayList<>();
+                String host = uri.getHost();
 
-                final String host = uri.getHost();
-
-                if (host.startsWith("127.0.0.1") || host.startsWith("localhost") || StringUtils.contains
-                        (nonProxyHostsValue, host)) {
-                    proxyList.add(Proxy.NO_PROXY);
+                if (!StringUtils.isEmpty(host)) {
+                    if (host.startsWith(DEFAULT_HOST_IP) || host.startsWith(DEFAULT_HOST) || StringUtils
+                            .isEmpty(nonProxyHostsValue) || StringUtils.contains(nonProxyHostsValue, host) ||
+                            StringUtils.isEmpty(proxyHost) || StringUtils.isEmpty(proxyPort)) {
+                        proxyList.add(Proxy.NO_PROXY);
+                    } else {
+                        proxyList.add(new Proxy(Proxy.Type.HTTP,
+                                new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort))));
+                    }
                 } else {
-                    proxyList.add(new Proxy(Proxy.Type.HTTP,
-                            new InetSocketAddress(proxyHost, Integer.parseInt(proxyPort))));
+                    log.error("Host is null. Host could not be empty or null");
                 }
-
                 return proxyList;
             }
 


### PR DESCRIPTION
## Purpose
> As per the current configurations it is mandatory to set a value for http.nonProxyHosts property in order to the server to run on 'change-ip' mode. With this modification, it is made optional where even without this property IoT server can be run on 'change-ip' mode. 'Change-ip' mode is where the server is configured to run on a different IP other than localhost

## Goals
> This fix will allow bypassing the proxy-related configurations if they were not set on the iot-server.sh file 

## Approach
> With this modification, it is made optional where even without the property "http.nonProxyHosts", IoT server can be run on 'change-ip' mode. 

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
>  N/A

## Certification
>  N/A

## Marketing
>  N/A

## Automation tests
 > Can not automate

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A