### PR TITLE
Checking for pending operations before adding an operation

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -190,7 +190,7 @@ public class OperationManagerImpl implements OperationManager {
 
                 if (pendingDeviceList.size() > 0) {
                     if (authorizedDeviceList.size() == pendingDeviceList.size()) {
-                        log.info("All the devices contain a pending operation for the Operation Code: "
+                        log.debug("All the devices contain a pending operation for the Operation Code: "
                                 + operationCode);
                         Activity activity = new Activity();
                         //Send the operation statuses only for admin triggered operations

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -190,8 +190,10 @@ public class OperationManagerImpl implements OperationManager {
 
                 if (pendingDeviceList.size() > 0) {
                     if (authorizedDeviceList.size() == pendingDeviceList.size()) {
-                        log.debug("All the devices contain a pending operation for the Operation Code: "
-                                + operationCode);
+                        if (log.isDebugEnabled()) {
+                            log.debug("All the devices contain a pending operation for the Operation Code: "
+                                    + operationCode);
+                        }
                         Activity activity = new Activity();
                         //Send the operation statuses only for admin triggered operations
                         String deviceType = validDeviceIds.get(0).getType();

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -186,19 +186,19 @@ public class OperationManagerImpl implements OperationManager {
                     if (hasExistingTaskOperation) {
                         pendingDeviceList.add(deviceId);
                     }
-
                 }
 
-                if(pendingDeviceList.size()>0){
+                if (pendingDeviceList.size() > 0) {
                     if (authorizedDeviceList.size() == pendingDeviceList.size()) {
-                        log.info("All the devices contain a pending operation for the Operation Code: "+operationCode);
+                        log.info("All the devices contain a pending operation for the Operation Code: "
+                                + operationCode);
                         Activity activity = new Activity();
                         //Send the operation statuses only for admin triggered operations
                         String deviceType = validDeviceIds.get(0).getType();
                         activity.setActivityStatus(this.getActivityStatus(deviceValidationResult, deviceAuthorizationResult,
                                 deviceType));
                         return activity;
-                    }else{
+                    } else {
                         authorizedDeviceList.removeAll(pendingDeviceList);
                     }
                 }


### PR DESCRIPTION
This is related to the creation of new activity even though a pending activity exist. The fix checks the pending activity status of a given device and if it exist, a new operation won't be created. 