### PR TITLE
Fix https://github.com/wso2/product-iots/issues/1857

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/api/ActivityInfoProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.api/src/main/java/org/wso2/carbon/device/mgt/jaxrs/service/api/ActivityInfoProviderService.java
@@ -430,6 +430,12 @@ public interface ActivityInfoProviderService {
                     required = false)
             @QueryParam("since") String since,
             @ApiParam(
+                    name = "initiatedBy",
+                    value = "The user, who initiated the operation. If is done by the task, the SYSTEM will be returned." +
+                            " And if a user adds the operation, username is returned",
+                    required = false)
+            @QueryParam("initiatedBy") String initiatedBy,
+            @ApiParam(
                     name = "offset",
                     value = "The starting pagination index for the complete list of qualified items.",
                     required = false,

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/OperationManager.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/OperationManager.java
@@ -102,7 +102,11 @@ public interface OperationManager {
 
     int getTotalCountOfFilteredActivities(String operationCode) throws  OperationManagementException;
 
+    List<Activity> getActivitiesUpdatedAfterByUser(long timestamp, String user, int limit, int offset) throws OperationManagementException;
+
     int getActivityCountUpdatedAfter(long timestamp) throws OperationManagementException;
+
+    int getActivityCountUpdatedAfterByUser(long timestamp, String user) throws OperationManagementException;
 
     /**
      * retrive the push notification strategy.

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/OperationManagerImpl.java
@@ -935,6 +935,22 @@ public class OperationManagerImpl implements OperationManager {
     }
 
     @Override
+    public List<Activity> getActivitiesUpdatedAfterByUser(long timestamp, String user, int limit, int offset)
+            throws OperationManagementException {
+        try {
+            OperationManagementDAOFactory.openConnection();
+            return operationDAO.getActivitiesUpdatedAfterByUser(timestamp, user, limit, offset);
+        } catch (SQLException e) {
+            throw new OperationManagementException("Error occurred while opening a connection to the data source.", e);
+        } catch (OperationManagementDAOException e) {
+            throw new OperationManagementException("Error occurred while getting the activity list changed after a " +
+                    "given time which are added by user : " + user, e);
+        } finally {
+            OperationManagementDAOFactory.closeConnection();
+        }
+    }
+
+    @Override
     public int getActivityCountUpdatedAfter(long timestamp) throws OperationManagementException {
         try {
             OperationManagementDAOFactory.openConnection();
@@ -944,6 +960,21 @@ public class OperationManagerImpl implements OperationManager {
         } catch (OperationManagementDAOException e) {
             throw new OperationManagementException("Error occurred while getting the activity count changed after a " +
                     "given time.", e);
+        } finally {
+            OperationManagementDAOFactory.closeConnection();
+        }
+    }
+
+    @Override
+    public int getActivityCountUpdatedAfterByUser(long timestamp, String user) throws OperationManagementException {
+        try {
+            OperationManagementDAOFactory.openConnection();
+            return operationDAO.getActivityCountUpdatedAfterByUser(timestamp, user);
+        } catch (SQLException e) {
+            throw new OperationManagementException("Error occurred while opening a connection to the data source.", e);
+        } catch (OperationManagementDAOException e) {
+            throw new OperationManagementException("Error occurred while getting the activity count changed after a " +
+                    "given time which are added by user :" + user, e);
         } finally {
             OperationManagementDAOFactory.closeConnection();
         }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/OperationDAO.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/OperationDAO.java
@@ -71,7 +71,11 @@ public interface OperationDAO {
 
     int getTotalCountOfFilteredActivities(String operationCode) throws OperationManagementDAOException;
 
+    List<Activity> getActivitiesUpdatedAfterByUser(long timestamp, String user, int limit, int offset) throws OperationManagementDAOException;
+
     int getActivityCountUpdatedAfter(long timestamp) throws OperationManagementDAOException;
+
+    int getActivityCountUpdatedAfterByUser(long timestamp, String user) throws OperationManagementDAOException;
 
     /**
      * This method provides operation mappings for given status

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -705,6 +705,171 @@ public class GenericOperationDAOImpl implements OperationDAO {
         return 0;
     }
 
+    @Override
+    public List<Activity> getActivitiesUpdatedAfterByUser(long timestamp, String user, int limit, int offset)
+            throws OperationManagementDAOException {
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        List<Activity> activities = new ArrayList<>();
+        try {
+            Connection conn = OperationManagementDAOFactory.getConnection();
+
+            int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+            String sql = "SELECT " +
+                    "    opr.ENROLMENT_ID, " +
+                    "    opr.CREATED_TIMESTAMP, " +
+                    "    opr.UPDATED_TIMESTAMP, " +
+                    "    opr.OPERATION_ID, " +
+                    "    opr.OPERATION_CODE, " +
+                    "    opr.OPERATION_TYPE, " +
+                    "    opr.STATUS, " +
+                    "    opr.DEVICE_ID, " +
+                    "    opr.DEVICE_IDENTIFICATION, " +
+                    "    opr.DEVICE_TYPE, " +
+                    "    ops.RECEIVED_TIMESTAMP, " +
+                    "    ops.ID OP_RES_ID, " +
+                    "    ops.OPERATION_RESPONSE , " +
+                    "    opr.INITIATED_BY " +
+                    " FROM " +
+                    "    (SELECT " +
+                    "            opm.ID MAPPING_ID, " +
+                    "            opm.ENROLMENT_ID, " +
+                    "            opm.CREATED_TIMESTAMP, " +
+                    "            opm.UPDATED_TIMESTAMP, " +
+                    "            opm.OPERATION_ID, " +
+                    "            op.OPERATION_CODE, " +
+                    "            op.INITIATED_BY, " +
+                    "            op.TYPE  OPERATION_TYPE, " +
+                    "            opm.STATUS, " +
+                    "            en.DEVICE_ID, " +
+                    "            de.DEVICE_IDENTIFICATION, " +
+                    "            dt.NAME  DEVICE_TYPE, " +
+                    "            de.TENANT_ID " +
+                    "    FROM" +
+                    "        DM_ENROLMENT_OP_MAPPING  opm " +
+                    "        INNER JOIN DM_OPERATION  op ON opm.OPERATION_ID = op.ID " +
+                    "        INNER JOIN DM_ENROLMENT  en ON opm.ENROLMENT_ID = en.ID " +
+                    "        INNER JOIN DM_DEVICE  de ON en.DEVICE_ID = de.ID " +
+                    "        INNER JOIN DM_DEVICE_TYPE  dt ON dt.ID = de.DEVICE_TYPE_ID " +
+                    "    WHERE " +
+                    "        opm.UPDATED_TIMESTAMP > ?  AND op.INITIATED_BY = ?" +
+                    "            AND de.TENANT_ID = ? " +
+                    "    ORDER BY opm.UPDATED_TIMESTAMP " +
+                    "    LIMIT ? OFFSET ?) opr " +
+                    " LEFT JOIN DM_DEVICE_OPERATION_RESPONSE ops ON opr.MAPPING_ID = ops.EN_OP_MAP_ID " +
+                    " WHERE " +
+                    "    opr.UPDATED_TIMESTAMP > ? AND opr.INITIATED_BY = ?" +
+                    "    AND opr.TENANT_ID = ? ";
+
+            stmt = conn.prepareStatement(sql);
+
+            stmt.setLong(1, timestamp);
+            stmt.setString(2, user);
+            stmt.setInt(3, tenantId);
+            stmt.setInt(4, limit);
+            stmt.setInt(5, offset);
+            stmt.setLong(6, timestamp);
+            stmt.setString(7, user);
+            stmt.setInt(8, tenantId);
+
+            rs = stmt.executeQuery();
+
+            int operationId = 0;
+            int enrolmentId = 0;
+            int responseId = 0;
+            Activity activity = null;
+            ActivityStatus activityStatus = null;
+            while (rs.next()) {
+
+                if (operationId != rs.getInt("OPERATION_ID")) {
+                    activity = new Activity();
+                    activities.add(activity);
+                    List<ActivityStatus> statusList = new ArrayList<>();
+                    activityStatus = new ActivityStatus();
+
+                    operationId = rs.getInt("OPERATION_ID");
+                    enrolmentId = rs.getInt("ENROLMENT_ID");
+
+                    activity.setType(Activity.Type.valueOf(rs.getString("OPERATION_TYPE")));
+                    activity.setCreatedTimeStamp(new java.util.Date(rs.getLong(("CREATED_TIMESTAMP")) * 1000).toString());
+                    activity.setCode(rs.getString("OPERATION_CODE"));
+                    activity.setInitiatedBy(rs.getString("INITIATED_BY"));
+
+                    DeviceIdentifier deviceIdentifier = new DeviceIdentifier();
+                    deviceIdentifier.setId(rs.getString("DEVICE_IDENTIFICATION"));
+                    deviceIdentifier.setType(rs.getString("DEVICE_TYPE"));
+                    activityStatus.setDeviceIdentifier(deviceIdentifier);
+
+                    activityStatus.setStatus(ActivityStatus.Status.valueOf(rs.getString("STATUS")));
+
+                    List<OperationResponse> operationResponses = new ArrayList<>();
+                    if (rs.getInt("UPDATED_TIMESTAMP") != 0) {
+                        activityStatus.setUpdatedTimestamp(new java.util.Date(
+                                rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
+
+                    }
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                    activityStatus.setResponses(operationResponses);
+                    statusList.add(activityStatus);
+                    activity.setActivityStatus(statusList);
+                    activity.setActivityId(OperationDAOUtil.getActivityId(rs.getInt("OPERATION_ID")));
+
+                }
+
+                if (operationId == rs.getInt("OPERATION_ID") && enrolmentId != rs.getInt("ENROLMENT_ID")) {
+                    activityStatus = new ActivityStatus();
+
+                    activity.setType(Activity.Type.valueOf(rs.getString("OPERATION_TYPE")));
+                    activity.setCreatedTimeStamp(new java.util.Date(rs.getLong(("CREATED_TIMESTAMP")) * 1000).toString());
+                    activity.setCode(rs.getString("OPERATION_CODE"));
+
+                    DeviceIdentifier deviceIdentifier = new DeviceIdentifier();
+                    deviceIdentifier.setId(rs.getString("DEVICE_IDENTIFICATION"));
+                    deviceIdentifier.setType(rs.getString("DEVICE_TYPE"));
+                    activityStatus.setDeviceIdentifier(deviceIdentifier);
+
+                    activityStatus.setStatus(ActivityStatus.Status.valueOf(rs.getString("STATUS")));
+
+                    List<OperationResponse> operationResponses = new ArrayList<>();
+                    if (rs.getInt("UPDATED_TIMESTAMP") != 0) {
+                        activityStatus.setUpdatedTimestamp(new java.util.Date(
+                                rs.getLong(("UPDATED_TIMESTAMP")) * 1000).toString());
+                    }
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        operationResponses.add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                    activityStatus.setResponses(operationResponses);
+                    activity.getActivityStatus().add(activityStatus);
+
+                    enrolmentId = rs.getInt("ENROLMENT_ID");
+                }
+
+                if (rs.getInt("OP_RES_ID") != 0 && responseId != rs.getInt("OP_RES_ID")) {
+                    if (rs.getTimestamp("RECEIVED_TIMESTAMP") != (null)) {
+                        activityStatus.getResponses().add(OperationDAOUtil.getOperationResponse(rs));
+                        responseId = rs.getInt("OP_RES_ID");
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new OperationManagementDAOException("Error occurred while getting the operation details from " +
+                    "the database.", e);
+        } catch (ClassNotFoundException e) {
+            throw new OperationManagementDAOException("Error occurred while converting the operation response to string.", e);
+        } catch (IOException e) {
+            throw new OperationManagementDAOException("IO exception occurred while converting the operations responses.", e);
+        } finally {
+            OperationManagementDAOUtil.cleanupResources(stmt, rs);
+        }
+
+        return activities;
+
+    }
+
 
     @Override
     public List<Activity> getActivitiesUpdatedAfter(long timestamp, int limit,
@@ -882,6 +1047,40 @@ public class GenericOperationDAOImpl implements OperationDAO {
         } catch (SQLException e) {
             throw new OperationManagementDAOException(
                     "Error occurred while getting the activity count from " + "the database.", e);
+        } finally {
+            OperationManagementDAOUtil.cleanupResources(stmt, rs);
+        }
+        return 0;
+    }
+
+    @Override
+    public int getActivityCountUpdatedAfterByUser(long timestamp, String user) throws OperationManagementDAOException {
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+        try {
+            Connection conn = OperationManagementDAOFactory.getConnection();
+            String sql = "SELECT \n" +
+                    "    COUNT(*) AS COUNT\n" +
+                    "FROM\n" +
+                    "    DM_ENROLMENT_OP_MAPPING AS m\n" +
+                    "        INNER JOIN\n" +
+                    "    DM_ENROLMENT AS d ON m.ENROLMENT_ID = d.ID\n" +
+                    "    INNER JOIN \n" +
+                    "    DM_OPERATION dp ON dp.ID = m.OPERATION_ID \n" +
+                    "WHERE\n" +
+                    "    m.UPDATED_TIMESTAMP > ? AND dp.INITIATED_BY = ?\n" +
+                    "        AND d.TENANT_ID = ?";
+            stmt = conn.prepareStatement(sql);
+            stmt.setLong(1, timestamp);
+            stmt.setString(2, user);
+            stmt.setInt(3, PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId());
+            rs = stmt.executeQuery();
+            if (rs.next()) {
+                return rs.getInt("COUNT");
+            }
+        } catch (SQLException e) {
+            throw new OperationManagementDAOException("Error occurred while getting the activity count from " +
+                    "the database.", e);
         } finally {
             OperationManagementDAOUtil.cleanupResources(stmt, rs);
         }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
@@ -576,7 +576,11 @@ public interface DeviceManagementProviderService {
 
     int getTotalCountOfFilteredActivities(String operationCode) throws OperationManagementException;
 
+    List<Activity> getActivitiesUpdatedAfterByUser(long timestamp, String user, int limit, int offset) throws OperationManagementException;
+
     int getActivityCountUpdatedAfter(long timestamp) throws OperationManagementException;
+
+    int getActivityCountUpdatedAfterByUser(long timestamp, String user) throws OperationManagementException;
 
     List<MonitoringOperation> getMonitoringOperationList(String deviceType);
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -1557,8 +1557,19 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
     }
 
     @Override
+    public List<Activity> getActivitiesUpdatedAfterByUser(long timestamp, String user, int limit, int offset) throws OperationManagementException {
+        limit = DeviceManagerUtil.validateActivityListPageSize(limit);
+        return DeviceManagementDataHolder.getInstance().getOperationManager().getActivitiesUpdatedAfterByUser(timestamp, user, limit, offset);
+    }
+
+    @Override
     public int getActivityCountUpdatedAfter(long timestamp) throws OperationManagementException {
         return DeviceManagementDataHolder.getInstance().getOperationManager().getActivityCountUpdatedAfter(timestamp);
+    }
+
+    @Override
+    public int getActivityCountUpdatedAfterByUser(long timestamp, String user) throws OperationManagementException {
+        return DeviceManagementDataHolder.getInstance().getOperationManager().getActivityCountUpdatedAfterByUser(timestamp, user);
     }
 
     @Override


### PR DESCRIPTION
Filtering the activities based on the user who added the operation

## Purpose
> Filtering the activities based on the user who added the operation. Currently, filtering happens with timestamp. But it does not have a way to filter based on the username of the operation initiator

