### PR TITLE
Persisting profile operations as string values instead of Objects

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/ProfileOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/ProfileOperationDAOImpl.java
@@ -53,7 +53,7 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
 
             bao = new ByteArrayOutputStream();
             oos = new ObjectOutputStream(bao);
-            oos.writeObject(operation);
+            oos.writeObject(operation.getPayLoad());
 
             stmt.setInt(1, operationId);
             stmt.setBytes(2, bao.toByteArray());
@@ -101,7 +101,13 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
                 byte[] operationDetails = rs.getBytes("OPERATION_DETAILS");
                 bais = new ByteArrayInputStream(operationDetails);
                 ois = new ObjectInputStream(bais);
-                profileOperation = (ProfileOperation) ois.readObject();
+                Object obj = ois.readObject();
+                if(obj instanceof String){
+                    profileOperation = new ProfileOperation();
+                    profileOperation.setPayLoad(obj);
+                } else {
+                    profileOperation = (ProfileOperation) obj;
+                }
             }
         } catch (IOException e) {
             throw new OperationManagementDAOException("IO Error occurred while de serialize the profile " +
@@ -147,9 +153,17 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
                 byte[] operationDetails = rs.getBytes("OPERATION_DETAILS");
                 bais = new ByteArrayInputStream(operationDetails);
                 ois = new ObjectInputStream(bais);
-                profileOperation = (ProfileOperation) ois.readObject();
-                profileOperation.setStatus(status);
-                operationList.add(profileOperation);
+                Object obj = ois.readObject();
+                if(obj instanceof String){
+                    profileOperation = new ProfileOperation();
+                    profileOperation.setPayLoad(obj);
+                    profileOperation.setStatus(status);
+                    operationList.add(profileOperation);
+                } else {
+                    profileOperation = (ProfileOperation) obj;
+                    profileOperation.setStatus(status);
+                    operationList.add(profileOperation);
+                };
             }
 
         } catch (IOException e) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/ProfileOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/ProfileOperationDAOImpl.java
@@ -174,7 +174,7 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
                     profileOperation = (ProfileOperation) obj;
                     profileOperation.setStatus(status);
                     operationList.add(profileOperation);
-                };
+                }
             }
 
         } catch (IOException e) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/ProfileOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/ProfileOperationDAOImpl.java
@@ -99,11 +99,17 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
 
             if (rs.next()) {
                 byte[] operationDetails = rs.getBytes("OPERATION_DETAILS");
+                int oppId = rs.getInt("OPERATION_ID");
                 bais = new ByteArrayInputStream(operationDetails);
                 ois = new ObjectInputStream(bais);
                 Object obj = ois.readObject();
                 if(obj instanceof String){
+                    Operation opp =  super.getOperation(oppId);
                     profileOperation = new ProfileOperation();
+                    profileOperation.setCode(opp.getCode());
+                    profileOperation.setId(oppId);
+                    profileOperation.setCreatedTimeStamp(opp.getCreatedTimeStamp());
+                    profileOperation.setId(oppId);
                     profileOperation.setPayLoad(obj);
                 } else {
                     profileOperation = (ProfileOperation) obj;
@@ -126,7 +132,7 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
 
     @Override
     public List<? extends Operation> getOperationsByDeviceAndStatus(int enrolmentId,
-            Operation.Status status) throws OperationManagementDAOException {
+                                                                    Operation.Status status) throws OperationManagementDAOException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         ProfileOperation profileOperation;
@@ -150,12 +156,17 @@ public class ProfileOperationDAOImpl extends GenericOperationDAOImpl {
             rs = stmt.executeQuery();
 
             while (rs.next()) {
+                int oppId = rs.getInt("OPERATION_ID");
                 byte[] operationDetails = rs.getBytes("OPERATION_DETAILS");
                 bais = new ByteArrayInputStream(operationDetails);
                 ois = new ObjectInputStream(bais);
                 Object obj = ois.readObject();
                 if(obj instanceof String){
+                    Operation opp =  super.getOperation(oppId);
                     profileOperation = new ProfileOperation();
+                    profileOperation.setCode(opp.getCode());
+                    profileOperation.setId(oppId);
+                    profileOperation.setCreatedTimeStamp(opp.getCreatedTimeStamp());
                     profileOperation.setPayLoad(obj);
                     profileOperation.setStatus(status);
                     operationList.add(profileOperation);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/OperationManagementTests.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/operation/OperationManagementTests.java
@@ -67,6 +67,7 @@ public class OperationManagementTests extends BaseDeviceManagementTest {
     private static final String POLICY_OPERATION_CODE = "POLICY-TEST";
     private static final String CONFIG_OPERATION_CODE = "CONFIG-TEST";
     private static final String PROFILE_OPERATION_CODE = "PROFILE-TEST";
+    private static final String PROFILE_NOTIFICATION_CODE = "NOTIFICATION";
     private static final String DATE_FORMAT_NOW = "yyyy-MM-dd HH:mm:ss";
     private static final int NO_OF_DEVICES = 5;
     private static final String ADMIN_USER = "admin";
@@ -205,8 +206,10 @@ public class OperationManagementTests extends BaseDeviceManagementTest {
     @Test(dependsOnMethods = "addConfigOperation")
     public void addProfileOperation() throws DeviceManagementException, OperationManagementException,
             InvalidDeviceException {
-        Activity activity = this.operationMgtService.addOperation(getOperation(new ProfileOperation(),
-                Operation.Type.PROFILE, PROFILE_OPERATION_CODE),
+        Operation opp = getOperation(new ProfileOperation(),
+                Operation.Type.PROFILE, PROFILE_NOTIFICATION_CODE);
+        opp.setPayLoad("{\"messageText\":\"xyz\",\"messageTitle\":\"abc\"}");
+        Activity activity = this.operationMgtService.addOperation(opp ,
                 this.deviceIds);
         validateOperationResponse(activity, ActivityStatus.Status.PENDING);
     }


### PR DESCRIPTION
## Purpose
> Persisting profile operations as objects lead to serialization issues every time an object is updated, this was solved by adding a serializationID, however storing objects itself leads to redundancies as the same set of values are stored in multiple locations. 

## Approach
> Only the string payload pertaining to profile operations will be stored henceforth in the blob, when retrieving operations, it will be checked to see if the value in question is an instance of String, if not it will be assumed to be a profile operation object (as per legacy implementation). This will make the code backward compatible.