### PR TITLE
Handle NotNow response from device

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/Operation.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/Operation.java
@@ -37,7 +37,7 @@ public class Operation implements Serializable {
 	}
 
     public enum Status {
-        IN_PROGRESS, PENDING, COMPLETED, ERROR, REPEATED
+        IN_PROGRESS, PENDING, COMPLETED, ERROR, REPEATED, NOTNOW
     }
 
     public enum Control {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/OperationManager.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.common/src/main/java/org/wso2/carbon/device/mgt/common/operation/mgt/OperationManager.java
@@ -76,6 +76,9 @@ public interface OperationManager {
      */
     List<? extends Operation> getPendingOperations(DeviceIdentifier deviceId) throws OperationManagementException;
 
+    Operation getNextPendingOperation(DeviceIdentifier deviceId, long notNowOperationFrequency)
+            throws OperationManagementException;
+
     Operation getNextPendingOperation(DeviceIdentifier deviceId) throws OperationManagementException;
 
     void updateOperation(DeviceIdentifier deviceId, Operation operation) throws OperationManagementException;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/dto/operation/mgt/Operation.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/dto/operation/mgt/Operation.java
@@ -30,7 +30,7 @@ public class Operation implements Serializable {
 	}
 
     public enum Status {
-        IN_PROGRESS, PENDING, COMPLETED, ERROR, REPEATED
+        IN_PROGRESS, PENDING, COMPLETED, ERROR, REPEATED, NOTNOW
     }
 
     public enum Control {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/OperationDAO.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/OperationDAO.java
@@ -46,7 +46,7 @@ public interface OperationDAO {
 
     List<? extends Operation> getOperationsForDevice(int enrolmentId, PaginationRequest request) throws OperationManagementDAOException;
 
-    Operation getNextOperation(int enrolmentId) throws OperationManagementDAOException;
+    Operation getNextOperation(int enrolmentId, Operation.Status status) throws OperationManagementDAOException;
 
     boolean updateOperationStatus(int enrolmentId, int operationId,Operation.Status status)
             throws OperationManagementDAOException;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/operation/mgt/dao/impl/GenericOperationDAOImpl.java
@@ -1372,7 +1372,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
     }
 
     @Override
-    public Operation getNextOperation(int enrolmentId) throws OperationManagementDAOException {
+    public Operation getNextOperation(int enrolmentId, Operation.Status status) throws OperationManagementDAOException {
         PreparedStatement stmt = null;
         ResultSet rs = null;
         try {
@@ -1383,7 +1383,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                     "WHERE dm.ENROLMENT_ID = ? AND dm.STATUS = ?) om ON o.ID = om.OPERATION_ID " +
                     "ORDER BY om.UPDATED_TIMESTAMP ASC, om.ID ASC LIMIT 1");
             stmt.setInt(1, enrolmentId);
-            stmt.setString(2, Operation.Status.PENDING.toString());
+            stmt.setString(2, status.toString());
             rs = stmt.executeQuery();
 
             Operation operation = null;
@@ -1392,11 +1392,7 @@ public class GenericOperationDAOImpl implements OperationDAO {
                 operation.setType(OperationDAOUtil.getType(rs.getString("TYPE")));
                 operation.setId(rs.getInt("ID"));
                 operation.setCreatedTimeStamp(rs.getTimestamp("CREATED_TIMESTAMP").toString());
-//                if (rs.getTimestamp("RECEIVED_TIMESTAMP") == null) {
-//                    operation.setReceivedTimeStamp("");
-//                } else {
-//                    operation.setReceivedTimeStamp(rs.getTimestamp("RECEIVED_TIMESTAMP").toString());
-//                }
+
                 if (rs.getLong("UPDATED_TIMESTAMP") == 0) {
                     operation.setReceivedTimeStamp("");
                 } else {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
@@ -551,6 +551,9 @@ public interface DeviceManagementProviderService {
 
     Operation getNextPendingOperation(DeviceIdentifier deviceId) throws OperationManagementException;
 
+    Operation getNextPendingOperation(DeviceIdentifier deviceId, long notNowOperationFrequency)
+            throws OperationManagementException;
+
     void updateOperation(DeviceIdentifier deviceId, Operation operation) throws OperationManagementException;
 
     boolean updateProperties(DeviceIdentifier deviceId, List<Device.Property> properties) throws DeviceManagementException;

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -1445,8 +1445,15 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
 
     @Override
     public Operation getNextPendingOperation(DeviceIdentifier deviceId) throws OperationManagementException {
+        // // setting notNowOperationFrequency to -1 to avoid picking notnow operations
         return pluginRepository.getOperationManager(deviceId.getType(), this.getTenantId())
-                .getNextPendingOperation(deviceId);
+                .getNextPendingOperation(deviceId, -1);
+    }
+
+    public Operation getNextPendingOperation(DeviceIdentifier deviceId, long notNowOperationFrequency)
+            throws OperationManagementException {
+        return pluginRepository.getOperationManager(deviceId.getType(), this.getTenantId())
+                .getNextPendingOperation(deviceId, notNowOperationFrequency);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> This fixes the wso2/carbon-devicemgt-proprietary-plugins#168 and wso2/product-iots#1873

## Approach
> At the time of retrieving nextPendingOperation, it will first check for NotNow operations (based on the configured frequency value) and if exists, it fetches the NotNow operation, and if not it fetches the pending operation.
