### PR TITLE
Fix device monitoring task disabling issue

### DIFF
--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementPluginRepository.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/DeviceManagementPluginRepository.java
@@ -321,7 +321,7 @@ public class DeviceManagementPluginRepository implements DeviceManagerStartupLis
                     getDeviceTaskManagerService();
             OperationMonitoringTaskConfig operationMonitoringTaskConfig = deviceManagementService.
                     getOperationMonitoringConfig();
-            if (operationMonitoringTaskConfig != null) {
+            if (operationMonitoringTaskConfig != null && operationMonitoringTaskConfig.isEnabled()) {
                 deviceTaskManagerService.stopTask(deviceManagementService.getType(),
                         deviceManagementService.getOperationMonitoringConfig());
             }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/DeviceTaskManagerServiceComponent.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/internal/DeviceTaskManagerServiceComponent.java
@@ -89,7 +89,9 @@ public class DeviceTaskManagerServiceComponent {
         Map<String, OperationMonitoringTaskConfig> deviceConfigMap = DeviceMonitoringOperationDataHolder
                 .getInstance().getOperationMonitoringConfigFromMap();
         for (String platformType : new ArrayList<>(deviceConfigMap.keySet())) {
-            deviceTaskManagerService.startTask(platformType, deviceConfigMap.get(platformType));
+            if (deviceConfigMap.get(platformType).isEnabled()){
+                deviceTaskManagerService.startTask(platformType, deviceConfigMap.get(platformType));
+            }
             deviceConfigMap.remove(platformType);
         }
     }

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderService.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.device.mgt.common.EnrolmentInfo;
 import org.wso2.carbon.device.mgt.common.FeatureManager;
 import org.wso2.carbon.device.mgt.common.InvalidDeviceException;
 import org.wso2.carbon.device.mgt.common.MonitoringOperation;
+import org.wso2.carbon.device.mgt.common.OperationMonitoringTaskConfig;
 import org.wso2.carbon.device.mgt.common.PaginationRequest;
 import org.wso2.carbon.device.mgt.common.PaginationResult;
 import org.wso2.carbon.device.mgt.common.configuration.mgt.ConfigurationManagementException;
@@ -588,6 +589,8 @@ public interface DeviceManagementProviderService {
     List<MonitoringOperation> getMonitoringOperationList(String deviceType);
 
     int getDeviceMonitoringFrequency(String deviceType);
+
+    OperationMonitoringTaskConfig getDeviceMonitoringConfig(String deviceType);
 
     boolean isDeviceMonitoringEnabled(String deviceType);
 

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/service/DeviceManagementProviderServiceImpl.java
@@ -1598,6 +1598,13 @@ public class DeviceManagementProviderServiceImpl implements DeviceManagementProv
     }
 
     @Override
+    public OperationMonitoringTaskConfig getDeviceMonitoringConfig(String deviceType) {
+        int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
+        DeviceManagementService dms = pluginRepository.getDeviceManagementService(deviceType, tenantId);
+        return dms.getOperationMonitoringConfig();
+    }
+
+    @Override
     public boolean isDeviceMonitoringEnabled(String deviceType) {
         int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
         DeviceManagementService dms = pluginRepository.getDeviceManagementService(deviceType, tenantId);

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/task/impl/DeviceDetailsRetrieverTask.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/task/impl/DeviceDetailsRetrieverTask.java
@@ -16,16 +16,15 @@
  * under the License.
  */
 
-
 package org.wso2.carbon.device.mgt.core.task.impl;
 
-import com.google.gson.Gson;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.device.mgt.common.DeviceManagementException;
 import org.wso2.carbon.device.mgt.common.OperationMonitoringTaskConfig;
 import org.wso2.carbon.device.mgt.core.internal.DeviceManagementDataHolder;
+import org.wso2.carbon.device.mgt.core.service.DeviceManagementProviderService;
 import org.wso2.carbon.device.mgt.core.task.DeviceMgtTaskException;
 import org.wso2.carbon.device.mgt.core.task.DeviceTaskManager;
 import org.wso2.carbon.ntask.core.Task;
@@ -38,20 +37,12 @@ public class DeviceDetailsRetrieverTask implements Task {
 
     private static Log log = LogFactory.getLog(DeviceDetailsRetrieverTask.class);
     private String deviceType;
-    private String oppConfig;
-    private OperationMonitoringTaskConfig operationMonitoringTaskConfig;
     private boolean executeForTenants = false;
     private final String IS_CLOUD = "is.cloud";
 
     @Override
     public void setProperties(Map<String, String> map) {
         deviceType = map.get("DEVICE_TYPE");
-        oppConfig = map.get("OPPCONFIG");
-
-        Gson gson = new Gson();
-
-        operationMonitoringTaskConfig = gson.fromJson(oppConfig,
-                OperationMonitoringTaskConfig.class);
     }
 
     @Override
@@ -60,29 +51,33 @@ public class DeviceDetailsRetrieverTask implements Task {
 
     @Override
     public void execute() {
+        DeviceManagementProviderService deviceManagementProviderService = DeviceManagementDataHolder.getInstance()
+                .getDeviceManagementProvider();
+        OperationMonitoringTaskConfig operationMonitoringTaskConfig = deviceManagementProviderService
+                .getDeviceMonitoringConfig(deviceType);
 
-        if(System.getProperty(IS_CLOUD) != null && Boolean.parseBoolean(System.getProperty(IS_CLOUD))){
+        if (System.getProperty(IS_CLOUD) != null && Boolean.parseBoolean(System.getProperty(IS_CLOUD))) {
             executeForTenants = true;
         }
-        if(executeForTenants){
-            this.executeForAllTenants();
+        if (executeForTenants) {
+            this.executeForAllTenants(operationMonitoringTaskConfig);
         } else {
             if (log.isDebugEnabled()) {
                 log.debug("Device details retrieving task started to run.");
             }
-            DeviceTaskManager deviceTaskManager = new DeviceTaskManagerImpl(deviceType,
-                    operationMonitoringTaskConfig);
+            DeviceTaskManager deviceTaskManager = new DeviceTaskManagerImpl(deviceType, operationMonitoringTaskConfig);
             //pass the configurations also from here, monitoring tasks
             try {
-                deviceTaskManager.addOperations();
+                if (deviceManagementProviderService.isDeviceMonitoringEnabled(deviceType)) {
+                    deviceTaskManager.addOperations();
+                }
             } catch (DeviceMgtTaskException e) {
-                log.error(
-                        "Error occurred while trying to add the operations to device to retrieve device details.", e);
+                log.error("Error occurred while trying to add the operations to device to retrieve device details.", e);
             }
         }
     }
 
-    private void executeForAllTenants() {
+    private void executeForAllTenants(OperationMonitoringTaskConfig operationMonitoringTaskConfig) {
 
         if (log.isDebugEnabled()) {
             log.debug("Device details retrieving task started to run for all tenants.");

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/task/impl/DeviceTaskManagerServiceImpl.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/main/java/org/wso2/carbon/device/mgt/core/task/impl/DeviceTaskManagerServiceImpl.java
@@ -107,10 +107,12 @@ public class DeviceTaskManagerServiceImpl implements DeviceTaskManagerService {
             throws DeviceMgtTaskException {
 
         try {
+            int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
             TaskService taskService = DeviceManagementDataHolder.getInstance().getTaskService();
             if (taskService.isServerInit()) {
                 TaskManager taskManager = taskService.getTaskManager(TASK_TYPE);
-                taskManager.deleteTask(deviceType);
+                String taskName = deviceType +  String.valueOf(tenantId);
+                taskManager.deleteTask(taskName);
             }
         } catch (TaskException e) {
             int tenantId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantId();
@@ -131,8 +133,8 @@ public class DeviceTaskManagerServiceImpl implements DeviceTaskManagerService {
             TaskManager taskManager = taskService.getTaskManager(TASK_TYPE);
 
             if (taskManager.isTaskScheduled(deviceType)) {
-
-                taskManager.deleteTask(deviceType);
+                String taskName = deviceType +  String.valueOf(tenantId);
+                taskManager.deleteTask(taskName);
                 TaskInfo.TriggerInfo triggerInfo = new TaskInfo.TriggerInfo();
                 triggerInfo.setIntervalMillis(operationMonitoringTaskConfig.getFrequency());
                 triggerInfo.setRepeatCount(-1);
@@ -140,7 +142,7 @@ public class DeviceTaskManagerServiceImpl implements DeviceTaskManagerService {
                 Map<String, String> properties = new HashMap<>();
                 properties.put(TENANT_ID, String.valueOf(tenantId));
 
-                TaskInfo taskInfo = new TaskInfo(deviceType, TASK_CLASS, properties, triggerInfo);
+                TaskInfo taskInfo = new TaskInfo(taskName, TASK_CLASS, properties, triggerInfo);
 
                 taskManager.registerTask(taskInfo);
                 taskManager.rescheduleTask(taskInfo.getName());

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/TestDeviceManagementService.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/TestDeviceManagementService.java
@@ -43,7 +43,7 @@ public class TestDeviceManagementService implements DeviceManagementService {
     public TestDeviceManagementService(String deviceType, String tenantDomain) {
         providerType = deviceType;
         this.tenantDomain = tenantDomain;
-        this.operationCode = "default";
+        this.operationCode = "DEVICE_INFO";
     }
 
     @Override

--- a/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/task/DeviceTaskManagerTest.java
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.core/src/test/java/org/wso2/carbon/device/mgt/core/task/DeviceTaskManagerTest.java
@@ -19,6 +19,7 @@ package org.wso2.carbon.device.mgt.core.task;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -27,6 +28,8 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.device.mgt.common.Device;
 import org.wso2.carbon.device.mgt.common.DeviceIdentifier;
 import org.wso2.carbon.device.mgt.common.DeviceManagementException;
+import org.wso2.carbon.device.mgt.common.MonitoringOperation;
+import org.wso2.carbon.device.mgt.common.OperationMonitoringTaskConfig;
 import org.wso2.carbon.device.mgt.common.operation.mgt.Operation;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManagementException;
 import org.wso2.carbon.device.mgt.common.operation.mgt.OperationManager;
@@ -60,8 +63,6 @@ public class DeviceTaskManagerTest extends BaseDeviceManagementTest {
 
     private static final Log log = LogFactory.getLog(DeviceTaskManagerTest.class);
     private static final String NEW_DEVICE_TYPE = "NEW-DEVICE-TYPE";
-    private static final String DEVICE_DETAIL_RETRIEVER_OPPCONFIG = "{\"isEnabled\":true,\"frequency\":60000," +
-            "\"monitoringOperation\":[{\"taskName\":\"DEVICE_INFO\",\"recurrentTimes\":2}]}";
     private List<DeviceIdentifier> deviceIds;
     private DeviceTaskManager deviceTaskManager;
     private DeviceManagementProviderService deviceMgtProviderService;
@@ -76,7 +77,6 @@ public class DeviceTaskManagerTest extends BaseDeviceManagementTest {
         }
         List<Device> devices = TestDataHolder.generateDummyDeviceData(this.deviceIds);
         this.deviceMgtProviderService = new DeviceManagementProviderServiceImpl();
-
         DeviceManagementServiceComponent.notifyStartupListeners();
         DeviceManagementDataHolder.getInstance().setDeviceManagementProvider(this.deviceMgtProviderService);
         DeviceManagementDataHolder.getInstance()
@@ -152,7 +152,6 @@ public class DeviceTaskManagerTest extends BaseDeviceManagementTest {
         DeviceDetailsRetrieverTask deviceDetailsRetrieverTask = new DeviceDetailsRetrieverTask();
         Map<String, String> map = new HashMap<>();
         map.put("DEVICE_TYPE", TestDataHolder.TEST_DEVICE_TYPE);
-        map.put("OPPCONFIG", DEVICE_DETAIL_RETRIEVER_OPPCONFIG);
         deviceDetailsRetrieverTask.setProperties(map);
         deviceDetailsRetrieverTask.execute();
         for (DeviceIdentifier deviceId : deviceIds) {
@@ -172,7 +171,6 @@ public class DeviceTaskManagerTest extends BaseDeviceManagementTest {
         System.setProperty("is.cloud", "true");
         Map<String, String> map = new HashMap<>();
         map.put("DEVICE_TYPE", TestDataHolder.TEST_DEVICE_TYPE);
-        map.put("OPPCONFIG", DEVICE_DETAIL_RETRIEVER_OPPCONFIG);
         deviceDetailsRetrieverTask.setProperties(map);
         deviceDetailsRetrieverTask.execute();
         for (DeviceIdentifier deviceId : deviceIds) {

--- a/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
+++ b/components/device-mgt/org.wso2.carbon.device.mgt.ui/src/main/resources/jaggeryapps/devicemgt/app/conf/config.json
@@ -15,6 +15,9 @@
   "iOSConfigRoot": "%https.ip%/ios-enrollment/",
   "iOSAPIRoot": "%https.ip%/ios/",
   "adminService": "%https.ip%",
+  "deviceInfoServiceAPI" : "/api/device-mgt/%device-type%/v1.0/admin/devices/info",
+  "deviceLocationServiceAPI" : "/api/device-mgt/%device-type%/v1.0/admin/devices/location",
+  "iOSDeviceInfoServiceAPI" : "/api/device-mgt/%device-type%/v1.0/admin/devices/info",
   "gatewayEnabled": true,
   "oauthProvider": {
     "appRegistration": {


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix device monitoring task disabling issue.

## Goals
> In order to fix device monitoring task disabling issue, when device monitoring task is executing read the configuration by using DeviceManagementProviderService task and read the config and proceed.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK - Oracle JDK 1.8
> OS - UBUNTU 18.04
> Browser - Chrome